### PR TITLE
[feat] 일자리 저장 취소 버튼 추가

### DIFF
--- a/src/pages/Company/CompanyJobListPage.tsx
+++ b/src/pages/Company/CompanyJobListPage.tsx
@@ -28,7 +28,7 @@ const CompanyJobListPage = () => {
                                     <img
                                         src="/icons/plus_icon.svg"
                                         alt="추가"
-                                        className="w-[24px] h-[24px]"
+                                        className="w-[24px] h-[24px] cursor-pointer"
                                     />
                                     새 신청서 추가
                                 </button>

--- a/src/pages/Personal/JobDetailPage.tsx
+++ b/src/pages/Personal/JobDetailPage.tsx
@@ -1,38 +1,14 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import Topbar from '../../shared/components/topbar/Topbar';
+import { dummyJobs } from '../../shared/constants/dummyJobs';
 
-// test용 더미 추후 삭제 예정
-const dummyJobs = [
-    {
-        jobId: 1,
-        name: '죽전1동 행정복지센터 미화원',
-        image: '/icons/popular-dummy1.png',
-        details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-    },
-    {
-        jobId: 2,
-        name: '죽전2동 행정복지센터 미화원',
-        image: '/icons/popular-dummy1.png',
-        details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-    },
-    {
-        jobId: 3,
-        name: '죽전3동 행정복지센터 미화원',
-        image: '/icons/popular-dummy1.png',
-        details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-    },
-    {
-        jobId: 4,
-        name: '죽전4동 행정복지센터 미화원',
-        image: '/icons/popular-dummy1.png',
-        details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-    },
-];
 //다 다르게 이동됨
 const JobDetailPage = () => {
     const { jobId } = useParams();
     const navigate = useNavigate();
     const job = dummyJobs.find(job => job.jobId === Number(jobId));
+    const saved: number[] = JSON.parse(localStorage.getItem('savedJobs') || '[]');
+    const isSaved = job ? saved.includes(job.jobId) : false;
 
     // 유효하지 않은 id 처리
     if (!job) {
@@ -77,8 +53,9 @@ const JobDetailPage = () => {
                         </button>
                         <button
                             onClick={handleSave}
+                            disabled={isSaved}
                             className="w-[144px] h-[45px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[16px] font-medium text-black">
-                            저장
+                            {isSaved ? "저장됨" : "저장"}
                         </button>
                     </div>
                 </div>

--- a/src/pages/Personal/JobDraftsPage.tsx
+++ b/src/pages/Personal/JobDraftsPage.tsx
@@ -38,6 +38,7 @@ const dummyJobs: JobType[] = [
 ];
 
 const JobDraftsPage = () => {
+    const [jobs, setJobs] = useState<JobType[]>(dummyJobs);
     const [selected, setSelected] = useState(0);
     const [selectedJobId, setSelectedJobId] = useState<number | null>(null);
 
@@ -75,10 +76,10 @@ const JobDraftsPage = () => {
                         className="w-[291] flex flex-col items-center overflow-y-auto mt-[22px] space-y-9 scrollbar-hide"
                         style={{ maxHeight: "400px" }}
                     >
-                        {dummyJobs.map((job) => {
+                        {jobs.map((job) => {
                             const isSelected = selectedJobId === job.jobId;
                             return (
-                                <div key={job.jobId} className="flex flex-col items-start">
+                                <div key={job.jobId} className="flex flex-col items-start relative">
                                     <div className="flex items-center gap-[6px]">
                                         {/* 동그라미 */}
                                         <div
@@ -95,6 +96,17 @@ const JobDraftsPage = () => {
                                         >
                                             선택하기
                                         </div>
+                                        {/* 취소하기 */}
+                                        <img
+                                            src="/icons/close_icon.svg"
+                                            alt="취소"
+                                            className="w-[27px] h-[27px] cursor-pointer absolute right-0 top-0"
+                                            onClick={() => {
+                                                setSelectedJobId(null);
+                                                setJobs((prevJobs) => prevJobs.filter((j) => j.jobId !== job.jobId));
+                                            }}
+
+                                        />
                                     </div>
                                     <div
                                         className={`w-[291px] h-[362px] mt-[11px] rounded-[10px] overflow-hidden border-[1.3px] flex flex-col items-center

--- a/src/pages/Personal/JobRecommendationPage.tsx
+++ b/src/pages/Personal/JobRecommendationPage.tsx
@@ -1,34 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Topbar from '../../shared/components/topbar/Topbar';
-
-// test용 더미 추후 삭제 예정
-const dummyJobs = [
-  {
-    jobId: 1,
-    name: '죽전1동 행정복지센터 미화원',
-    image: '/icons/popular-dummy1.png',
-    details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-  },
-  {
-    jobId: 2,
-    name: '죽전2동 행정복지센터 미화원',
-    image: '/icons/popular-dummy1.png',
-    details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-  },
-  {
-    jobId: 3,
-    name: '죽전3동 행정복지센터 미화원',
-    image: '/icons/popular-dummy1.png',
-    details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-  },
-  {
-    jobId: 4,
-    name: '죽전4동 행정복지센터 미화원',
-    image: '/icons/popular-dummy1.png',
-    details: '거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원'
-  },
-];
+import { dummyJobs, JobType } from '../../shared/constants/dummyJobs';
 
 const JobRecommendationPage = () => {
   const [search, setSearch] = useState('');
@@ -68,7 +41,7 @@ const JobRecommendationPage = () => {
           <div className="mt-[17px] flex-1 w-full flex justify-center" style={{ minHeight: 0 }}>
             <div className="flex flex-col items-center overflow-y-auto gap-[41px] scrollbar-hide"
                         style={{ maxHeight: "400px" }}>
-              {dummyJobs.map((job) => (
+              {dummyJobs.map((job: JobType) => (
                 <div
                   key={job.jobId}
                   className="cursor-pointer"

--- a/src/pages/Personal/JobSavedPage.tsx
+++ b/src/pages/Personal/JobSavedPage.tsx
@@ -61,12 +61,12 @@ const JobSavedPage = () => {
         <div className="w-[291] flex flex-col items-center overflow-y-auto mt-[22px] space-y-8 scrollbar-hide"
           style={{ maxHeight: "450px" }}>
           {savedJobs.length === 0 ? (
-            <p className="text-gray-500">저장된 일자리가 없습니다.</p>
+            <p className="text-[#747474] text-[16px]">저장된 일자리가 없습니다.</p>
           ) : (
             savedJobs.map((job) => {
               const isSelected = selectedJobId === job.jobId;
               return (
-                <div key={job.jobId} className="flex flex-col ">
+                <div key={job.jobId} className="flex flex-col relative">
                   <div className="flex items-center gap-2">
                     {/* 동그라미 */}
                     <div
@@ -88,6 +88,16 @@ const JobSavedPage = () => {
                     >
                       선택하기
                     </div>
+                    {/* 취소하기 */}
+                    <img
+                      src="/icons/close_icon.svg"
+                      alt="취소"
+                      className="w-[27px] h-[27px] cursor-pointer absolute right-0 top-0 z-10"
+                      onClick={() => {
+                        setSelectedJobId(null);
+                        setSavedJobs((prev) => prev.filter((j) => j.jobId !== job.jobId));
+                      }}
+                    />
                   </div>
 
 

--- a/src/pages/Personal/JobSavedPage.tsx
+++ b/src/pages/Personal/JobSavedPage.tsx
@@ -1,44 +1,7 @@
 // src/pages/jobs/JobSavedPage.tsx
 import { useEffect, useState } from "react";
 import Topbar from "../../shared/components/topbar/Topbar";
-
-interface JobType {
-  jobId: number;
-  name: string;
-  image: string;
-  details: string;
-}
-
-const dummyJobs: JobType[] = [
-  {
-    jobId: 1,
-    name: "죽전1동 행정복지센터 미화원",
-    image: "/icons/popular-dummy1.png",
-    details:
-      "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
-  },
-  {
-    jobId: 2,
-    name: "죽전2동 행정복지센터 미화원",
-    image: "/icons/popular-dummy1.png",
-    details:
-      "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
-  },
-  {
-    jobId: 3,
-    name: "죽전3동 행정복지센터 미화원",
-    image: "/icons/popular-dummy1.png",
-    details:
-      "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
-  },
-  {
-    jobId: 4,
-    name: "죽전4동 행정복지센터 미화원",
-    image: "/icons/popular-dummy1.png",
-    details:
-      "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
-  },
-];
+import { dummyJobs, JobType } from '../../shared/constants/dummyJobs';
 
 const JobSavedPage = () => {
   const [savedJobs, setSavedJobs] = useState<JobType[]>([]);
@@ -96,6 +59,9 @@ const JobSavedPage = () => {
                       onClick={() => {
                         setSelectedJobId(null);
                         setSavedJobs((prev) => prev.filter((j) => j.jobId !== job.jobId));
+                        const savedIds: number[] = JSON.parse(localStorage.getItem('savedJobs') || '[]');
+                        const newIds = savedIds.filter((id) => id !== job.jobId);
+                        localStorage.setItem('savedJobs', JSON.stringify(newIds));
                       }}
                     />
                   </div>

--- a/src/pages/Personal/JobSavedPage.tsx
+++ b/src/pages/Personal/JobSavedPage.tsx
@@ -3,6 +3,12 @@ import { useEffect, useState } from "react";
 import Topbar from "../../shared/components/topbar/Topbar";
 import { dummyJobs, JobType } from '../../shared/constants/dummyJobs';
 
+const getSavedJobIds = (): number[] =>
+  JSON.parse(localStorage.getItem('savedJobs') || '[]');
+
+const setSavedJobIds = (ids: number[]) =>
+  localStorage.setItem('savedJobs', JSON.stringify(ids));
+
 const JobSavedPage = () => {
   const [savedJobs, setSavedJobs] = useState<JobType[]>([]);
   const [selectedJobId, setSelectedJobId] = useState<number | null>(null);
@@ -13,6 +19,13 @@ const JobSavedPage = () => {
     setSavedJobs(jobs);
   }, []);
 
+  const handleRemove = (jobId: number) => {
+    setSelectedJobId(null);
+    setSavedJobs((prev) => prev.filter((j) => j.jobId !== jobId));
+    const newIds = getSavedJobIds().filter((id) => id !== jobId);
+    setSavedJobIds(newIds);
+  };
+
   return (
     <Topbar>
       <div className="w-full h-full flex flex-col items-center">
@@ -20,8 +33,7 @@ const JobSavedPage = () => {
           <p className="text-[20px] font-semibold text-[#747474]">일자리 저장함</p>
         </div>
         {/* 스크롤 영역 */}
-        <div className="flex-1 w-full flex justify-center" style={{ minHeight: 0 }}></div>
-        <div className="w-[291] flex flex-col items-center overflow-y-auto mt-[22px] space-y-8 scrollbar-hide"
+        <div className="flex-1 w-full flex flex-col items-center overflow-y-auto mt-[22px] space-y-8 scrollbar-hide"
           style={{ maxHeight: "450px" }}>
           {savedJobs.length === 0 ? (
             <p className="text-[#747474] text-[16px]">저장된 일자리가 없습니다.</p>
@@ -56,17 +68,9 @@ const JobSavedPage = () => {
                       src="/icons/close_icon.svg"
                       alt="취소"
                       className="w-[27px] h-[27px] cursor-pointer absolute right-0 top-0 z-10"
-                      onClick={() => {
-                        setSelectedJobId(null);
-                        setSavedJobs((prev) => prev.filter((j) => j.jobId !== job.jobId));
-                        const savedIds: number[] = JSON.parse(localStorage.getItem('savedJobs') || '[]');
-                        const newIds = savedIds.filter((id) => id !== job.jobId);
-                        localStorage.setItem('savedJobs', JSON.stringify(newIds));
-                      }}
+                      onClick={() => handleRemove(job.jobId)}
                     />
                   </div>
-
-
                   <div
                     className={`
                       w-[291px] h-[362px] mt-[11px] rounded-[10px] overflow-hidden

--- a/src/shared/constants/dummyJobs.ts
+++ b/src/shared/constants/dummyJobs.ts
@@ -1,0 +1,34 @@
+export interface JobType {
+    jobId: number;
+    name: string;
+    image: string;
+    details: string;
+}
+export const dummyJobs: JobType[] = [
+    {
+        jobId: 1,
+        name: "죽전1동 행정복지센터 미화원",
+        image: "/icons/popular-dummy1.png",
+        details: "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
+    },
+    {
+        jobId: 2,
+        name: "죽전2동 행정복지센터 미화원",
+        image: "/icons/popular-dummy1.png",
+        details: "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
+    },
+    {
+        jobId: 3,
+        name: "죽전3동 행정복지센터 미화원",
+        image: "/icons/popular-dummy1.png",
+        details:
+            "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
+    },
+    {
+        jobId: 4,
+        name: "죽전4동 행정복지센터 미화원",
+        image: "/icons/popular-dummy1.png",
+        details:
+            "거리: 도보 및 지하철 20분, 시급: 12,240원, 근무시간: 월수금 2시간, 월급: 29만원",
+    },
+];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #40 

## 📝 작업 내용

<br />
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- test 더미데이터 constant로 분리.
- x아이콘을 추가 하여 저장한 일자리를 취소 가능하도록 구현.
- 이미 저장한 일자리는 저장->저장됨 버튼이 뜨도록 설정

## 🖼️ 구현 화면

<br />
<!-- 애니메이션이 있다면 gif나 영상 첨부 해주세요  -->
<img width="369" height="730" alt="화면 캡처 2025-07-26 234956" src="https://github.com/user-attachments/assets/f008c4e2-691f-4a6b-aaff-7bcd3ccf792d" />
<img width="366" height="739" alt="화면 캡처 2025-07-26 235012" src="https://github.com/user-attachments/assets/34d3afa3-d0bc-4595-a33b-77e41024cb19" />


## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
