### PR TITLE
[feat] 일반 사용자 로그인 및 회원가입 api 연동 

### DIFF
--- a/src/pages/Personal/Login.tsx
+++ b/src/pages/Personal/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import TopbarForLogin from '../../shared/components/topbar/TopbarForLogin';
+import { useLogin } from './hooks/useAuth';
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -9,6 +10,28 @@ const LoginPage = () => {
 
   const handleFindAccount = () => {
     navigate('/personal/find-account');
+  };
+
+  const loginMutation = useLogin();
+
+  const handleLogin = () => {
+    if (!id || !pw) {
+      alert('아이디와 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    loginMutation.mutate(
+      { username: id, password: pw },
+      {
+        onSuccess: () => {
+          alert('로그인 성공! 메인 페이지로 이동합니다.');
+          navigate('/', { replace: true });
+        },
+        onError: (error: unknown) => {
+          console.error('로그인 실패:', error);
+        },
+      }
+    );
   };
 
   return (
@@ -21,7 +44,11 @@ const LoginPage = () => {
         <div className="w-[320px] border-t border-[#d9d9d9] mb-[2.4rem]" />
 
         {/* 입력 폼 */}
-        <form className="flex flex-col items-center w-full">
+        <form
+          className="flex flex-col items-center w-full"
+          autoComplete="off"
+          onSubmit={(e) => e.preventDefault()}
+        >
           <input
             type="text"
             placeholder="아이디를 입력해주세요"
@@ -36,7 +63,10 @@ const LoginPage = () => {
             onChange={(e) => setPw(e.target.value)}
             className={`mb-[3rem] w-[270px] h-[45px] font-medium rounded-[8px] border border-[#e1e1e1] text-[1.6rem] px-[13px] py-[16px] focus:outline-black ${pw ? 'text-black' : 'text-[#C2C2C2]'}`}
           />
-          <button className="w-[270px] bg-[#08D485] text-black text-[16px] py-[12px] rounded-[8px] mb-[26px] shadow transition">
+          <button
+            className="w-[270px] bg-[#08D485] text-black text-[16px] py-[12px] rounded-[8px] mb-[26px] shadow transition"
+            onClick={handleLogin}
+          >
             로그인
           </button>
         </form>
@@ -47,6 +77,7 @@ const LoginPage = () => {
             비밀번호를 잊어버리셨나요?
           </p>
           <button
+            type="button"
             className="w-[270px] border-[1.3px] border-[#08D485] text-black text-[16px] py-[12px] rounded-[8px] mb-[26px]"
             onClick={handleFindAccount}
           >

--- a/src/pages/Personal/apis/auth.ts
+++ b/src/pages/Personal/apis/auth.ts
@@ -3,6 +3,7 @@ import {
   SeniorSignupRequest,
   SendVerificationRequest,
   VerifyCodeRequest,
+  LoginRequest,
 } from '../types/auth';
 
 // 시니어 회원가입
@@ -30,3 +31,9 @@ export const checkUsernameAvailability = async (username: string) => {
   const response = await axiosInstance.get(`/api/auth/check-username?username=${username}`);
   return response.data;
 }; 
+
+// 일반 로그인
+export const login = async (data: LoginRequest) => {
+  const response = await axiosInstance.post('/api/auth/login', data);
+  return response.data;
+};

--- a/src/pages/Personal/apis/auth.ts
+++ b/src/pages/Personal/apis/auth.ts
@@ -1,0 +1,32 @@
+import axiosInstance from '../../../shared/apis/axiosInstance';
+import {
+  SeniorSignupRequest,
+  SendVerificationRequest,
+  VerifyCodeRequest,
+} from '../types/auth';
+
+// 시니어 회원가입
+export const signupSenior = async (data: SeniorSignupRequest) => {
+  const response = await axiosInstance.post('/api/auth/signup/senior', data);
+  return response.data;
+};
+
+// 인증번호 발송 - body로 phone 전송
+export const sendVerificationCode = async (data: SendVerificationRequest) => {
+  const response = await axiosInstance.post('/api/sms/send', {
+    phone: data.phone
+  });
+  return response.data;
+};
+
+// 인증번호 확인
+export const verifyCode = async (data: VerifyCodeRequest) => {
+  const response = await axiosInstance.post('/api/sms/verify', data);
+  return response.data;
+};
+
+// 아이디 중복 확인 - username을 query params로 전송
+export const checkUsernameAvailability = async (username: string) => {
+  const response = await axiosInstance.get(`/api/auth/check-username?username=${username}`);
+  return response.data;
+}; 

--- a/src/pages/Personal/apis/auth.ts
+++ b/src/pages/Personal/apis/auth.ts
@@ -4,11 +4,18 @@ import {
   SendVerificationRequest,
   VerifyCodeRequest,
   LoginRequest,
+  ProtectorSignupRequest,
 } from '../types/auth';
 
 // 시니어 회원가입
 export const signupSenior = async (data: SeniorSignupRequest) => {
   const response = await axiosInstance.post('/api/auth/signup/senior', data);
+  return response.data;
+};
+
+// 보호자 회원가입
+export const signupProtector = async (data: ProtectorSignupRequest) => {
+  const response = await axiosInstance.post('/api/auth/signup/protector', data);
   return response.data;
 };
 

--- a/src/pages/Personal/components/user/signIn/Care/CareSignIn.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareSignIn.tsx
@@ -1,19 +1,37 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import CareStep1 from './CareStep1';
 import CareStep2 from './CareStep2';
 import CareStep3 from './CareStep3';
 import CareStep4 from './CareStep4';
 import CareStep5 from './CareStep5';
 import TopbarForLogin from '../../../../../../shared/components/topbar/TopbarForLogin';
+import { useProtectorSignup, useSeniorSignup } from '../../../../hooks/useAuth';
+import {
+  ProtectorSignupRequest,
+  SeniorSignupRequest,
+  Gender,
+  Job,
+  ExperiencePeriod,
+} from '../../../../types/auth';
 
 const CareSignIn = () => {
+  const navigate = useNavigate();
   const [step, setStep] = useState(1);
+  const [protectorId, setProtectorId] = useState<number | null>(null);
+
+  const protectorSignupMutation = useProtectorSignup();
+  const seniorSignupMutation = useSeniorSignup();
+
+  // Step1: 보호자 본인 인증
   const [step1State, setStep1State] = useState({
     carrier: '',
     name: '',
     phone: '',
     smsCode: '',
   });
+
+  // Step2: 보호자 계정 정보
   const [step2State, setStep2State] = useState({
     id: '',
     idCheck: '',
@@ -21,13 +39,18 @@ const CareSignIn = () => {
     password: '',
     passwordConfirm: '',
   });
+
+  // Step3: 시니어 기본 정보
   const [step3State, setStep3State] = useState({
+    name: '',
     id: '',
     idCheck: '',
     isIdAvailable: false,
     password: '',
     passwordConfirm: '',
   });
+
+  // Step4: 시니어 상세 정보
   const [step4State, setStep4State] = useState({
     type: '',
     age: '',
@@ -38,6 +61,8 @@ const CareSignIn = () => {
     job: '',
     period: '',
   });
+
+  // Step5: 시니어 인증
   const [step5State, setStep5State] = useState({
     carrier: '',
     name: '',
@@ -45,8 +70,105 @@ const CareSignIn = () => {
     smsCode: '',
   });
 
-  const handlesubmit = () => {
-    alert('회원가입 완료');
+  // Step2 완료 시 보호자 회원가입 진행 (84-102번째 줄 수정)
+  const handleProtectorSignup = () => {
+    const protectorData: ProtectorSignupRequest = {
+      username: step2State.idCheck,
+      password: step2State.password,
+      name: step1State.name,
+      phone: step1State.phone,
+      providerType: null,
+      providerUserId: null,
+    };
+
+    protectorSignupMutation.mutate(protectorData, {
+      onSuccess: (data) => {
+        console.log('보호자 회원가입 성공:', data);
+
+        // 서버에서 protectorId 받아서 저장
+        const receivedProtectorId = data.result?.userId;
+
+        if (receivedProtectorId) {
+          setProtectorId(receivedProtectorId);
+          console.log('✅ protectorId 저장됨:', receivedProtectorId);
+          setStep(3);
+        } else {
+          console.error('protectorId를 찾을 수 없음:', data);
+        }
+      },
+      onError: (error) => {
+        console.error('보호자 회원가입 실패:', error);
+      },
+    });
+  };
+
+  // 직업 매핑 함수
+  const mapJobToEnum = (job: string): Job => {
+    const jobMap: Record<string, Job> = {
+      주부: 'HOUSEWIFE',
+      회사원: 'EMPLOYEE',
+      공무원: 'PUBLIC_OFFICER',
+      전문직: 'PROFESSIONAL',
+      예술가: 'ARTIST',
+      사업가: 'BUSINESS_OWNER',
+      기타: 'ETC',
+    };
+    return jobMap[job] || 'ETC';
+  };
+
+  // 경력 기간 매핑 함수
+  const mapPeriodToEnum = (period: string): ExperiencePeriod => {
+    const periodMap: Record<string, ExperiencePeriod> = {
+      '6개월 미만': 'LESS_THAN_6_MONTHS',
+      '6개월 ~ 1년': 'SIX_MONTHS_TO_1_YEAR',
+      '1년 ~ 3년': 'ONE_TO_THREE_YEARS',
+      '3년 ~ 5년': 'THREE_TO_FIVE_YEARS',
+      '5년 ~ 10년': 'FIVE_TO_TEN_YEARS',
+      '10년 이상': 'OVER_TEN_YEARS',
+    };
+    return periodMap[period] || 'LESS_THAN_6_MONTHS';
+  };
+
+  // Step5 완료 시 시니어 회원가입
+  const handleSeniorSignup = () => {
+    if (!protectorId) {
+      alert('보호자 정보가 없습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    const seniorData: SeniorSignupRequest = {
+      username: step3State.id,
+      password: step3State.password,
+      name: step3State.name,
+      age: parseInt(step4State.age),
+      gender: step4State.gender as Gender,
+      phoneNum: step4State.phone,
+      zipcode: '',
+      roadAddress: step4State.address,
+      detailAddress: step4State.detailAddress || undefined,
+      job: mapJobToEnum(step4State.job),
+      experiencePeriod: mapPeriodToEnum(step4State.period),
+
+      // 보호자 연결 정보
+      protectorId: protectorId,
+      relation: '모녀', // 임시 값 (서버 수정 후 제거)
+
+      // 소셜 로그인 관련
+      providerType: null,
+      providerUserId: null,
+    };
+
+    seniorSignupMutation.mutate(seniorData, {
+      onSuccess: (data) => {
+        console.log('시니어 회원가입 성공:', data);
+        alert('보호자 및 어르신 회원가입이 모두 완료되었습니다.');
+        navigate('/personal/login');
+      },
+      onError: (error) => {
+        console.error('시니어 회원가입 실패:', error);
+        alert('회원가입 중 오류가 발생했습니다.');
+      },
+    });
   };
 
   return (
@@ -62,7 +184,7 @@ const CareSignIn = () => {
         <CareStep2
           state={step2State}
           setState={setStep2State}
-          onNext={() => setStep(3)}
+          onNext={handleProtectorSignup}
         />
       )}
       {step === 3 && (
@@ -83,7 +205,7 @@ const CareSignIn = () => {
         <CareStep5
           state={step5State}
           setState={setStep5State}
-          onSubmit={handlesubmit}
+          onSubmit={handleSeniorSignup}
         />
       )}
     </TopbarForLogin>

--- a/src/pages/Personal/components/user/signIn/Care/CareStep1.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareStep1.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import SignUpHeader from '../SignUpHeader';
 import NextButton from '../NextButton';
+import {
+  useSendVerificationCode,
+  useVerifyCode,
+} from '../../../../hooks/useAuth';
 
 type Step1State = {
   carrier: string;
@@ -21,6 +25,65 @@ const selectClass =
   'h-[4.5rem] border border-[#E1E1E1] rounded-[0.8rem] px-[1.6rem] py-[1.3rem] bg-white text-[#BDBDBD] text-[1.6rem]';
 
 const CareStep1 = ({ state, setState, onNext }: CareStep1Props) => {
+  const [isVerificationSent, setIsVerificationSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+
+  const sendVerificationMutation = useSendVerificationCode();
+  const verifyCodeMutation = useVerifyCode();
+
+  const handleSendVerification = () => {
+    if (!state.phone) {
+      alert('전화번호를 입력해주세요.');
+      return;
+    }
+
+    sendVerificationMutation.mutate(
+      { phone: state.phone },
+      {
+        onSuccess: () => {
+          alert('인증번호가 발송되었습니다.');
+          setIsVerificationSent(true);
+        },
+        onError: (error) => {
+          console.error('인증번호 발송 실패:', error);
+          alert('인증번호 발송에 실패했습니다. 다시 시도해주세요.');
+        },
+      }
+    );
+  };
+
+  const handleVerifyCode = () => {
+    if (!state.smsCode) {
+      alert('인증번호를 입력해주세요.');
+      return;
+    }
+
+    verifyCodeMutation.mutate(
+      {
+        phone: state.phone,
+        verificationCode: state.smsCode,
+      },
+      {
+        onSuccess: () => {
+          alert('인증이 완료되었습니다.');
+          setIsVerified(true);
+        },
+        onError: (error) => {
+          console.error('인증 실패:', error);
+          alert('인증번호가 올바르지 않습니다.');
+        },
+      }
+    );
+  };
+
+  const handleNext = () => {
+    if (!state.name || !state.phone) {
+      alert('모든 항목을 입력해주세요.');
+      return;
+    }
+    onNext();
+  };
+
   return (
     <div className="flex flex-col items-center w-full pt-[0.4rem] px-[1.2rem]">
       <SignUpHeader title="회원가입 하기" />
@@ -46,12 +109,33 @@ const CareStep1 = ({ state, setState, onNext }: CareStep1Props) => {
           placeholder="인증번호를 입력하세요"
           value={state.smsCode}
           onChange={(e) => setState((s) => ({ ...s, smsCode: e.target.value }))}
+          disabled={!isVerificationSent}
         />
-        <button className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium">
-          인증하기
-        </button>
+        {!isVerificationSent ? (
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium"
+            onClick={handleSendVerification}
+            disabled={sendVerificationMutation.isPending || !state.phone}
+          >
+            {sendVerificationMutation.isPending ? '발송 중...' : '인증하기'}
+          </button>
+        ) : (
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium"
+            onClick={handleVerifyCode}
+            disabled={
+              verifyCodeMutation.isPending || !state.smsCode || isVerified
+            }
+          >
+            {verifyCodeMutation.isPending
+              ? '확인 중...'
+              : isVerified
+                ? '인증완료'
+                : '확인'}
+          </button>
+        )}
       </div>
-      <NextButton onClick={onNext}>다음</NextButton>
+      <NextButton onClick={handleNext}>다음</NextButton>
     </div>
   );
 };

--- a/src/pages/Personal/components/user/signIn/Care/CareStep2.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareStep2.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NextButton from '../NextButton';
 import SignUpHeader from '../SignUpHeader';
+import { useCheckUsername } from '../../../../hooks/useAuth';
 
 type Step2State = {
   id: string;
@@ -19,46 +20,127 @@ type CareStep2Props = {
 const inputClass =
   'w-full h-[4.5rem] border border-[#E1E1E1] rounded-[0.8rem] px-[1.6rem] py-[1.3rem] mb-3 bg-white placeholder-[#BDBDBD] text-[1.6rem]';
 
-const CareStep2 = ({ state, setState, onNext }: CareStep2Props) => (
-  <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3.3rem]">
-    <SignUpHeader title="회원가입 하기" />
-    <div className="w-[29.4rem]">
-      <p className="text-[#747474] mb-[2.3rem] text-[1.6rem] font-semibold">
-        회원가입을 위해 필수정보를 입력해주세요
-      </p>
-      <div className="flex gap-2 mt-[1.6rem] mb-1">
-        <input
-          className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#BDBDBD]'}`}
-          placeholder="본인 아이디를 입력해주세요"
-          value={state.idCheck}
-          onChange={(e) => setState((s) => ({ ...s, idCheck: e.target.value }))}
-        />
-        <button className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium h-[4.5rem]">
-          확인
-        </button>
-      </div>
-      <div className="text-[#08D485] text-[1.4rem] mb-[2.2rem] mt-[0.6rem]">
-        쓸 수 있는 아이디입니다
-      </div>
-      <input
-        className={`${inputClass} ${state.password ? 'text-black' : 'text-[#BDBDBD]'}`}
-        placeholder="비밀번호를 입력해주세요"
-        type="password"
-        value={state.password}
-        onChange={(e) => setState((s) => ({ ...s, password: e.target.value }))}
-      />
-      <input
-        className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#BDBDBD]'}`}
-        placeholder="비밀번호를 다시 입력해주세요"
-        type="password"
-        value={state.passwordConfirm}
-        onChange={(e) =>
-          setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+const CareStep2 = ({ state, setState, onNext }: CareStep2Props) => {
+  const [usernameMessage, setUsernameMessage] = useState('');
+  const [hasChecked, setHasChecked] = useState(false);
+
+  const checkUsernameMutation = useCheckUsername();
+
+  const handleCheckUsername = () => {
+    if (!state.idCheck.trim()) {
+      alert('아이디를 입력해주세요.');
+      return;
+    }
+
+    checkUsernameMutation.mutate(state.idCheck, {
+      onSuccess: (data: any) => {
+        setHasChecked(true);
+        const isAvailable = data.result && data.result.includes('사용 가능한');
+
+        if (isAvailable) {
+          setState((s) => ({ ...s, id: state.idCheck, isIdAvailable: true }));
+          setUsernameMessage('사용 가능한 아이디입니다.');
+        } else {
+          setState((s) => ({ ...s, isIdAvailable: false }));
+          setUsernameMessage('이미 사용 중인 아이디입니다.');
         }
-      />
+      },
+      onError: (error: unknown) => {
+        console.error('아이디 확인 실패:', error);
+        setHasChecked(true);
+        setState((s) => ({ ...s, isIdAvailable: false }));
+        setUsernameMessage('이미 사용중인 아이디입니다.');
+      },
+    });
+  };
+
+  const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setState((s) => ({ ...s, idCheck: e.target.value, isIdAvailable: false }));
+    setUsernameMessage('');
+    setHasChecked(false);
+  };
+
+  const handleNext = () => {
+    if (!state.password || !state.passwordConfirm) {
+      alert('비밀번호를 입력해주세요.');
+      return;
+    }
+    if (state.password !== state.passwordConfirm) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (!state.isIdAvailable) {
+      alert('아이디 중복 확인을 해주세요.');
+      return;
+    }
+    onNext();
+  };
+
+  const getMessageStyle = () => {
+    if (!hasChecked) return 'text-[#BDBDBD]';
+    return state.isIdAvailable ? 'text-[#08D485]' : 'text-red-500';
+  };
+
+  const getDefaultMessage = () => {
+    return usernameMessage;
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3.3rem]">
+      <SignUpHeader title="회원가입 하기" />
+      <div className="w-[29.4rem]">
+        <p className="text-[#747474] mb-[2.3rem] text-[1.6rem] font-semibold">
+          회원가입을 위해 필수정보를 입력해주세요
+        </p>
+        <div className="flex gap-2 mt-[1.6rem] mb-1">
+          <input
+            className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#BDBDBD]'}`}
+            placeholder="본인 아이디를 입력해주세요"
+            value={state.idCheck}
+            onChange={handleUsernameChange}
+          />
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium h-[4.5rem]"
+            onClick={handleCheckUsername}
+            disabled={checkUsernameMutation.isPending || !state.idCheck.trim()}
+          >
+            {checkUsernameMutation.isPending ? '확인 중...' : '중복 확인'}
+          </button>
+        </div>
+        <div
+          className={`text-[1.4rem] mb-[2.2rem] mt-[0.6rem] ml-[0.9rem] ${getMessageStyle()}`}
+        >
+          {getDefaultMessage()}
+        </div>
+        <input
+          className={`${inputClass} ${state.password ? 'text-black' : 'text-[#BDBDBD]'}`}
+          placeholder="비밀번호를 입력해주세요"
+          type="password"
+          value={state.password}
+          onChange={(e) =>
+            setState((s) => ({ ...s, password: e.target.value }))
+          }
+        />
+        <input
+          className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#BDBDBD]'}`}
+          placeholder="비밀번호를 다시 입력해주세요"
+          type="password"
+          value={state.passwordConfirm}
+          onChange={(e) =>
+            setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+          }
+        />
+        {state.password &&
+          state.passwordConfirm &&
+          state.password !== state.passwordConfirm && (
+            <div className="text-red-500 text-[1.4rem] mt-[-0.5rem] mb-[1rem] ml-[0.9rem]">
+              비밀번호가 일치하지 않습니다.
+            </div>
+          )}
+      </div>
+      <NextButton onClick={handleNext}>다음</NextButton>
     </div>
-    <NextButton onClick={onNext}>다음</NextButton>
-  </div>
-);
+  );
+};
 
 export default CareStep2;

--- a/src/pages/Personal/components/user/signIn/Care/CareStep3.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareStep3.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NextButton from '../NextButton';
 import SignUpHeader from '../SignUpHeader';
+import { useCheckUsername } from '../../../../hooks/useAuth';
 
 type Step3State = {
+  name: string;
   id: string;
   idCheck: string;
   isIdAvailable: boolean;
@@ -19,52 +21,133 @@ type CareStep3Props = {
 const inputClass =
   'w-full h-[4.5rem] border border-[#E1E1E1] rounded-[0.8rem] px-[1.4rem] py-[1.3rem] mb-3 bg-white placeholder-[#c2c2c2] text-[1.6rem] font-bold';
 
-const CareStep3 = ({ state, setState, onNext }: CareStep3Props) => (
-  <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3rem]">
-    <SignUpHeader title="회원가입 하기" />
-    <div className="w-[30.6rem]">
-      <p className="text-[#747474] mb-[2.3rem] text-[1.5rem] font-semibold">
-        회원가입을 위해 어르신의 필수정보를 입력해주세요
-      </p>
-      <input
-        className={`${inputClass} ${state.id ? 'text-black' : 'text-[#c2c2c2]'}`}
-        placeholder="어르신 이름을 입력해주세요"
-        value={state.id}
-        onChange={(e) => setState((s) => ({ ...s, id: e.target.value }))}
-      />
-      <div className="flex gap-2 mt-[0.9rem] mb-1">
-        <input
-          className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#c2c2c2]'}`}
-          placeholder="어르신의 아이디를 입력해주세요"
-          value={state.idCheck}
-          onChange={(e) => setState((s) => ({ ...s, idCheck: e.target.value }))}
-        />
-        <button className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-bold h-[4.5rem]">
-          확인
-        </button>
-      </div>
-      <div className="text-[#08D485] text-[1.4rem] font-bold mb-[2.2rem] mt-[1.3rem]">
-        쓸 수 있는 아이디입니다
-      </div>
-      <input
-        className={`${inputClass} ${state.password ? 'text-black' : 'text-[#c2c2c2]'}`}
-        placeholder="비밀번호를 입력해주세요"
-        type="password"
-        value={state.password}
-        onChange={(e) => setState((s) => ({ ...s, password: e.target.value }))}
-      />
-      <input
-        className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#c2c2c2]'}`}
-        placeholder="비밀번호를 다시 입력해주세요"
-        type="password"
-        value={state.passwordConfirm}
-        onChange={(e) =>
-          setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+const CareStep3 = ({ state, setState, onNext }: CareStep3Props) => {
+  const [usernameMessage, setUsernameMessage] = useState('');
+  const [hasChecked, setHasChecked] = useState(false);
+
+  const checkUsernameMutation = useCheckUsername();
+
+  const handleCheckUsername = () => {
+    if (!state.idCheck.trim()) {
+      alert('아이디를 입력해주세요.');
+      return;
+    }
+
+    checkUsernameMutation.mutate(state.idCheck, {
+      onSuccess: (data: any) => {
+        setHasChecked(true);
+        const isAvailable = data.result && data.result.includes('사용 가능한');
+
+        if (isAvailable) {
+          setState((s) => ({ ...s, id: state.idCheck, isIdAvailable: true }));
+          setUsernameMessage('사용 가능한 아이디입니다.');
+        } else {
+          setState((s) => ({ ...s, isIdAvailable: false }));
+          setUsernameMessage('이미 사용 중인 아이디입니다.');
         }
-      />
+      },
+      onError: (error: unknown) => {
+        console.error('아이디 확인 실패:', error);
+        setHasChecked(true);
+        setState((s) => ({ ...s, isIdAvailable: false }));
+        setUsernameMessage('이미 사용 중인 아이디입니다.');
+      },
+    });
+  };
+
+  const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setState((s) => ({ ...s, idCheck: e.target.value, isIdAvailable: false }));
+    setUsernameMessage('');
+    setHasChecked(false);
+  };
+
+  const handleNext = () => {
+    if (!state.id || !state.idCheck) {
+      alert('모든 항목을 입력해주세요.');
+      return;
+    }
+    if (!state.isIdAvailable) {
+      alert('아이디 중복 확인을 해주세요.');
+      return;
+    }
+    if (state.password !== state.passwordConfirm) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    onNext();
+  };
+
+  const getMessageStyle = () => {
+    if (!hasChecked) return 'text-[#c2c2c2]';
+    return state.isIdAvailable ? 'text-[#08D485]' : 'text-red-500';
+  };
+
+  const getDefaultMessage = () => {
+    return usernameMessage;
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3rem]">
+      <SignUpHeader title="회원가입 하기" />
+      <div className="w-[30.6rem]">
+        <p className="text-[#747474] mb-[2.3rem] text-[1.5rem] font-semibold">
+          회원가입을 위해 어르신의 필수정보를 입력해주세요
+        </p>
+        <input
+          className={`${inputClass} ${state.name ? 'text-black' : 'text-[#c2c2c2]'}`}
+          placeholder="어르신 이름을 입력해주세요"
+          value={state.name}
+          onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
+        />
+        <div className="flex gap-2 mt-[0.9rem] mb-1">
+          <input
+            className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#c2c2c2]'}`}
+            placeholder="어르신의 아이디를 입력해주세요"
+            value={state.idCheck}
+            onChange={handleUsernameChange}
+          />
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-bold h-[4.5rem]"
+            onClick={handleCheckUsername}
+            disabled={checkUsernameMutation.isPending || !state.idCheck.trim()}
+          >
+            {checkUsernameMutation.isPending ? '확인 중...' : '확인'}
+          </button>
+        </div>
+        <div
+          className={`text-[1.4rem] font-bold mb-[2.2rem] mt-[1.3rem] ${getMessageStyle()}`}
+        >
+          {getDefaultMessage()}
+        </div>
+        <input
+          className={`${inputClass} ${state.password ? 'text-black' : 'text-[#c2c2c2]'}`}
+          placeholder="비밀번호를 입력해주세요"
+          type="password"
+          value={state.password}
+          onChange={(e) =>
+            setState((s) => ({ ...s, password: e.target.value }))
+          }
+        />
+        <input
+          className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#c2c2c2]'}`}
+          placeholder="비밀번호를 다시 입력해주세요"
+          type="password"
+          value={state.passwordConfirm}
+          onChange={(e) =>
+            setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+          }
+        />
+        {state.password &&
+          state.passwordConfirm &&
+          state.password !== state.passwordConfirm && (
+            <div className="text-red-500 text-[1.4rem] mt-[-0.5rem] mb-[1rem]">
+              비밀번호가 일치하지 않습니다.
+            </div>
+          )}
+      </div>
+      <NextButton onClick={handleNext}>다음</NextButton>
     </div>
-    <NextButton onClick={onNext}>다음</NextButton>
-  </div>
-);
+  );
+};
 
 export default CareStep3;

--- a/src/pages/Personal/components/user/signIn/Care/CareStep5.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareStep5.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 import SignUpHeader from '../SignUpHeader';
 import NextButton from '../NextButton';
+import {
+  useSendVerificationCode,
+  useVerifyCode,
+} from '../../../../hooks/useAuth';
 
 type Step5State = {
   carrier: string;
@@ -21,6 +25,69 @@ const selectClass =
   'h-[4.5rem] border border-[#E1E1E1] rounded-[0.8rem] px-[1.6rem] py-[1.3rem] text-[#BDBDBD] text-[1.6rem] font-medium';
 
 const CareStep5 = ({ state, setState, onSubmit }: CareStep5Props) => {
+  const [isVerificationSent, setIsVerificationSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+
+  const sendVerificationMutation = useSendVerificationCode();
+  const verifyCodeMutation = useVerifyCode();
+
+  const handleSendVerification = () => {
+    if (!state.phone) {
+      alert('전화번호를 입력해주세요.');
+      return;
+    }
+
+    sendVerificationMutation.mutate(
+      { phone: state.phone },
+      {
+        onSuccess: () => {
+          alert('인증번호가 발송되었습니다.');
+          setIsVerificationSent(true);
+        },
+        onError: (error) => {
+          console.error('인증번호 발송 실패:', error);
+          alert('인증번호 발송에 실패했습니다. 다시 시도해주세요.');
+        },
+      }
+    );
+  };
+
+  const handleVerifyCode = () => {
+    if (!state.smsCode) {
+      alert('인증번호를 입력해주세요.');
+      return;
+    }
+
+    verifyCodeMutation.mutate(
+      {
+        phone: state.phone,
+        verificationCode: state.smsCode,
+      },
+      {
+        onSuccess: () => {
+          alert('인증이 완료되었습니다.');
+          setIsVerified(true);
+        },
+        onError: (error) => {
+          console.error('인증 실패:', error);
+          alert('인증번호가 올바르지 않습니다.');
+        },
+      }
+    );
+  };
+
+  const handleSubmit = () => {
+    if (!state.name || !state.phone) {
+      alert('모든 항목을 입력해주세요.');
+      return;
+    }
+    if (!isVerified) {
+      alert('인증번호 확인을 완료해주세요.');
+      return;
+    }
+    onSubmit();
+  };
+
   return (
     <div className="flex flex-col items-center w-full pt-[0.4rem] px-[1.1rem] pb-[8rem]">
       <SignUpHeader title="회원가입 하기" />
@@ -29,37 +96,54 @@ const CareStep5 = ({ state, setState, onSubmit }: CareStep5Props) => {
         <br />
         어르신의 정보를 입력해주세요.
       </div>
-
       <input
-        className={`${inputClass} w-[29.4rem] mb-[2rem] ${state.name ? 'text-black' : 'text-[#BDBDBD]'}`}
-        placeholder="이름을 입력하세요"
+        className={`${inputClass} w-[29.4rem] mb-[2.1rem] ${state.name ? 'text-black' : 'text-[#BDBDBD]'}`}
+        placeholder="어르신 이름을 입력하세요"
         value={state.name}
         onChange={(e) => setState((s) => ({ ...s, name: e.target.value }))}
       />
       <input
         className={`${inputClass} w-[29.4rem] ${state.phone ? 'text-black' : 'text-[#BDBDBD]'}`}
-        placeholder="전화번호를 입력하세요"
+        placeholder="어르신 전화번호를 입력하세요"
         value={state.phone}
         onChange={(e) => setState((s) => ({ ...s, phone: e.target.value }))}
       />
-      <div className="w-[29.4rem] text-left font-medium text-[#747474] text-[1.6rem] mb-[2rem] mt-[2rem]">
+      <div className="w-[29.4rem] text-left font-semibold text-[#747474] text-[1.6rem] mb-[2.1rem] mt-[3.6rem]">
         인증번호(SMS)
       </div>
-      <div className="w-[29.4rem] flex gap-[1.4rem] mb-2">
+      <div className="w-[29.4rem] flex gap-[1.4rem] mb-3">
         <input
           className={`w-[18.3rem] ${selectClass} mb-0 ${state.smsCode ? 'text-black' : 'text-[#BDBDBD]'}`}
           placeholder="인증번호를 입력하세요"
           value={state.smsCode}
           onChange={(e) => setState((s) => ({ ...s, smsCode: e.target.value }))}
+          disabled={!isVerificationSent}
         />
-        <button className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-semibold">
-          인증번호 전송
-        </button>
+        {!isVerificationSent ? (
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium"
+            onClick={handleSendVerification}
+            disabled={sendVerificationMutation.isPending || !state.phone}
+          >
+            {sendVerificationMutation.isPending ? '발송 중...' : '인증하기'}
+          </button>
+        ) : (
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium"
+            onClick={handleVerifyCode}
+            disabled={
+              verifyCodeMutation.isPending || !state.smsCode || isVerified
+            }
+          >
+            {verifyCodeMutation.isPending
+              ? '확인 중...'
+              : isVerified
+                ? '인증완료'
+                : '확인'}
+          </button>
+        )}
       </div>
-      <div className="w-[29.4rem] text-left text-[#01AA42] text-[1.4rem] mt-[0.8rem] mb-6 font-medium">
-        어르신께 문자로 온 인증번호를 입력해주세요
-      </div>
-      <NextButton onClick={onSubmit}>회원가입 완료</NextButton>
+      <NextButton onClick={handleSubmit}>회원가입 완료</NextButton>
     </div>
   );
 };

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorSignIn.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorSignIn.tsx
@@ -1,17 +1,29 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import SeniorStep1 from './SeniorStep1';
 import SeniorStep2 from './SeniorStep2';
 import SeniorStep3 from './SeniorStep3';
 import TopbarForLogin from '../../../../../../shared/components/topbar/TopbarForLogin';
+import { useSeniorSignup } from '../../../../hooks/useAuth';
+import {
+  SeniorSignupRequest,
+  Gender,
+  Job,
+  ExperiencePeriod,
+} from '../../../../types/auth';
 
 const SeniorSignIn = () => {
+  const navigate = useNavigate();
   const [step, setStep] = useState(1);
+  const signupMutation = useSeniorSignup();
+
   const [step1State, setStep1State] = useState({
     carrier: '',
     name: '',
     phone: '',
     smsCode: '',
   });
+
   const [step2State, setStep2State] = useState({
     id: '',
     idCheck: '',
@@ -29,10 +41,73 @@ const SeniorSignIn = () => {
     detailAddress: '',
     job: '',
     period: '',
+    zipcode: '',
+    roadAddress: '',
   });
 
-  const handlesubmit = () => {
-    alert('회원가입 완료');
+  // 직업 매핑 함수
+  const mapJobToEnum = (job: string): Job => {
+    const jobMap: Record<string, Job> = {
+      주부: 'HOUSEWIFE',
+      회사원: 'EMPLOYEE',
+      공무원: 'PUBLIC_OFFICER',
+      전문직: 'PROFESSIONAL',
+      예술가: 'ARTIST',
+      사업가: 'BUSINESS_OWNER',
+      기타: 'ETC',
+    };
+    return jobMap[job] || 'ETC';
+  };
+
+  // 경력 기간 매핑 함수
+  const mapPeriodToEnum = (period: string): ExperiencePeriod => {
+    const periodMap: Record<string, ExperiencePeriod> = {
+      '6개월 미만': 'LESS_THAN_6_MONTHS',
+      '6개월 ~ 1년': 'SIX_MONTHS_TO_1_YEAR',
+      '1년 ~ 3년': 'ONE_TO_THREE_YEARS',
+      '3년 ~ 5년': 'THREE_TO_FIVE_YEARS',
+      '5년 ~ 10년': 'FIVE_TO_TEN_YEARS',
+      '10년 이상': 'OVER_TEN_YEARS',
+    };
+    return periodMap[period] || 'LESS_THAN_6_MONTHS';
+  };
+
+  const handleSubmit = () => {
+    const signupData: SeniorSignupRequest = {
+      username: step2State.id,
+      password: step2State.password,
+      name: step1State.name,
+      age: parseInt(step3State.age),
+      gender: step3State.gender as Gender,
+      phoneNum: step1State.phone,
+      zipcode: step3State.zipcode,
+      roadAddress: step3State.roadAddress,
+      detailAddress: step3State.detailAddress || undefined,
+      job: mapJobToEnum(step3State.job),
+      experiencePeriod: mapPeriodToEnum(step3State.period),
+
+      // 보호자 연결 없음
+      protectorId: null,
+      relation: undefined,
+
+      // 일반 회원가입
+      providerType: null,
+      providerUserId: null,
+    };
+
+    console.log('전송할 회원가입 데이터:', signupData);
+
+    signupMutation.mutate(signupData, {
+      onSuccess: (data: unknown) => {
+        console.log('회원가입 성공:', data);
+        alert('회원가입이 완료되었습니다!');
+        navigate('/personal/login');
+      },
+      onError: (error: unknown) => {
+        console.error('회원가입 오류:', error);
+        alert('회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      },
+    });
   };
 
   return (
@@ -55,7 +130,8 @@ const SeniorSignIn = () => {
         <SeniorStep3
           state={step3State}
           setState={setStep3State}
-          onSubmit={handlesubmit}
+          onSubmit={handleSubmit}
+          isLoading={signupMutation.isPending}
         />
       )}
     </TopbarForLogin>

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
@@ -26,6 +26,7 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
 
   const checkUsernameMutation = useCheckUsername();
 
+  // 아이디 중복 확인
   const handleCheckUsername = () => {
     if (!state.idCheck.trim()) {
       alert('아이디를 입력해주세요.');
@@ -33,9 +34,12 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
     }
 
     checkUsernameMutation.mutate(state.idCheck, {
-      onSuccess: (data: { isAvailable: boolean }) => {
+      onSuccess: (data: any) => {
         setHasChecked(true);
-        if (data.isAvailable) {
+
+        const isAvailable = data.result && data.result.includes('사용 가능한');
+
+        if (isAvailable) {
           setState((s) => ({ ...s, id: state.idCheck, isIdAvailable: true }));
           setUsernameMessage('사용 가능한 아이디입니다.');
         } else {
@@ -52,6 +56,7 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
     });
   };
 
+  // 아이디 입력 변경
   const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setState((s) => ({ ...s, idCheck: e.target.value, isIdAvailable: false }));
     setUsernameMessage('');
@@ -59,12 +64,16 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
   };
 
   const handleNext = () => {
-    if (!state.isIdAvailable || !state.password || !state.passwordConfirm) {
+    if (!state.password || !state.passwordConfirm) {
       alert('모든 항목을 입력해주세요.');
       return;
     }
     if (state.password !== state.passwordConfirm) {
       alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (!state.isIdAvailable) {
+      alert('아이디 중복 확인을 해주세요.');
       return;
     }
     onNext();
@@ -77,10 +86,6 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
   };
 
   const getDefaultMessage = () => {
-    if (!hasChecked) {
-      alert('아이디 중복 확인을 해주세요');
-      return;
-    }
     return usernameMessage;
   };
 
@@ -103,7 +108,7 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
             onClick={handleCheckUsername}
             disabled={checkUsernameMutation.isPending || !state.idCheck.trim()}
           >
-            {checkUsernameMutation.isPending ? '확인 중...' : '확인'}
+            {checkUsernameMutation.isPending ? '확인 중...' : '중복 확인'}
           </button>
         </div>
         <div

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
@@ -51,7 +51,7 @@ const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
         console.error('아이디 확인 실패:', error);
         setHasChecked(true);
         setState((s) => ({ ...s, isIdAvailable: false }));
-        setUsernameMessage('아이디 확인 중 오류가 발생했습니다.');
+        setUsernameMessage('이미 사용 중인 아이디입니다.');
       },
     });
   };

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorStep2.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NextButton from '../NextButton';
 import SignUpHeader from '../SignUpHeader';
+import { useCheckUsername } from '../../../../hooks/useAuth';
 
 type Step2State = {
   id: string;
@@ -19,46 +20,126 @@ type SeniorStep2Props = {
 const inputClass =
   'w-full h-[4.5rem] border border-[#E1E1E1] rounded-[0.8rem] px-[1.6rem] py-[1.3rem] mb-3 bg-white placeholder-[#C2C2C2] text-[1.6rem]';
 
-const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => (
-  <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3.3rem]">
-    <SignUpHeader title="회원가입 하기" />
-    <div className="w-[29.4rem]">
-      <p className="text-[#747474] mb-[2.3rem] text-[1.6rem] font-semibold">
-        회원가입을 위해 필수정보를 입력해주세요
-      </p>
-      <div className="flex gap-2 mt-[0.9rem] mb-1">
-        <input
-          className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#C2C2C2]'}`}
-          placeholder="아이디를 입력해주세요"
-          value={state.idCheck}
-          onChange={(e) => setState((s) => ({ ...s, idCheck: e.target.value }))}
-        />
-        <button className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium h-[4.5rem]">
-          확인
-        </button>
-      </div>
-      <div className="text-[#08D485] text-[1.4rem] mb-[2.2rem] mt-[0.6rem] ml-[0.9rem]">
-        쓸 수 있는 아이디입니다
-      </div>
-      <input
-        className={`${inputClass} ${state.password ? 'text-black' : 'text-[#C2C2C2]'}`}
-        placeholder="비밀번호를 입력해주세요"
-        type="password"
-        value={state.password}
-        onChange={(e) => setState((s) => ({ ...s, password: e.target.value }))}
-      />
-      <input
-        className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#C2C2C2]'}`}
-        placeholder="비밀번호를 다시 입력해주세요"
-        type="password"
-        value={state.passwordConfirm}
-        onChange={(e) =>
-          setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+const SeniorStep2 = ({ state, setState, onNext }: SeniorStep2Props) => {
+  const [usernameMessage, setUsernameMessage] = useState('');
+  const [hasChecked, setHasChecked] = useState(false);
+
+  const checkUsernameMutation = useCheckUsername();
+
+  const handleCheckUsername = () => {
+    if (!state.idCheck.trim()) {
+      alert('아이디를 입력해주세요.');
+      return;
+    }
+
+    checkUsernameMutation.mutate(state.idCheck, {
+      onSuccess: (data: { isAvailable: boolean }) => {
+        setHasChecked(true);
+        if (data.isAvailable) {
+          setState((s) => ({ ...s, id: state.idCheck, isIdAvailable: true }));
+          setUsernameMessage('사용 가능한 아이디입니다.');
+        } else {
+          setState((s) => ({ ...s, isIdAvailable: false }));
+          setUsernameMessage('이미 사용 중인 아이디입니다.');
         }
-      />
+      },
+      onError: (error: unknown) => {
+        console.error('아이디 확인 실패:', error);
+        setHasChecked(true);
+        setState((s) => ({ ...s, isIdAvailable: false }));
+        setUsernameMessage('아이디 확인 중 오류가 발생했습니다.');
+      },
+    });
+  };
+
+  const handleUsernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setState((s) => ({ ...s, idCheck: e.target.value, isIdAvailable: false }));
+    setUsernameMessage('');
+    setHasChecked(false);
+  };
+
+  const handleNext = () => {
+    if (!state.isIdAvailable || !state.password || !state.passwordConfirm) {
+      alert('모든 항목을 입력해주세요.');
+      return;
+    }
+    if (state.password !== state.passwordConfirm) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    onNext();
+  };
+
+  // 메시지 색상을 isIdAvailable로 결정
+  const getMessageStyle = () => {
+    if (!hasChecked) return 'text-[#c2c2c2]';
+    return state.isIdAvailable ? 'text-[#08D485]' : 'text-red-500';
+  };
+
+  const getDefaultMessage = () => {
+    if (!hasChecked) {
+      alert('아이디 중복 확인을 해주세요');
+      return;
+    }
+    return usernameMessage;
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full pt-[0.4rem] px-[3.3rem]">
+      <SignUpHeader title="회원가입 하기" />
+      <div className="w-[29.4rem]">
+        <p className="text-[#747474] mb-[2.3rem] text-[1.6rem] font-semibold">
+          회원가입을 위해 필수정보를 입력해주세요
+        </p>
+        <div className="flex gap-2 mt-[0.9rem] mb-1">
+          <input
+            className={`${inputClass} ${state.idCheck ? 'text-black' : 'text-[#C2C2C2]'}`}
+            placeholder="아이디를 입력해주세요"
+            value={state.idCheck}
+            onChange={handleUsernameChange}
+          />
+          <button
+            className="bg-[#08D485] w-[9.6rem] text-black rounded-[8px] py-[1.2rem] text-[1.4rem] font-medium h-[4.5rem]"
+            onClick={handleCheckUsername}
+            disabled={checkUsernameMutation.isPending || !state.idCheck.trim()}
+          >
+            {checkUsernameMutation.isPending ? '확인 중...' : '확인'}
+          </button>
+        </div>
+        <div
+          className={`text-[1.4rem] mb-[2.2rem] mt-[0.6rem] ml-[0.9rem] ${getMessageStyle()}`}
+        >
+          {getDefaultMessage()}
+        </div>
+        <input
+          className={`${inputClass} ${state.password ? 'text-black' : 'text-[#C2C2C2]'}`}
+          placeholder="비밀번호를 입력해주세요"
+          type="password"
+          value={state.password}
+          onChange={(e) =>
+            setState((s) => ({ ...s, password: e.target.value }))
+          }
+        />
+        <input
+          className={`${inputClass} ${state.passwordConfirm ? 'text-black' : 'text-[#C2C2C2]'}`}
+          placeholder="비밀번호를 다시 입력해주세요"
+          type="password"
+          value={state.passwordConfirm}
+          onChange={(e) =>
+            setState((s) => ({ ...s, passwordConfirm: e.target.value }))
+          }
+        />
+        {state.password &&
+          state.passwordConfirm &&
+          state.password !== state.passwordConfirm && (
+            <div className="text-red-500 text-[1.4rem] mt-[-0.5rem] mb-[1rem] ml-[0.9rem]">
+              비밀번호가 일치하지 않습니다.
+            </div>
+          )}
+      </div>
+      <NextButton onClick={handleNext}>다음</NextButton>
     </div>
-    <NextButton onClick={onNext}>다음</NextButton>
-  </div>
-);
+  );
+};
 
 export default SeniorStep2;

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorStep3.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorStep3.tsx
@@ -50,15 +50,23 @@ type Step3State = {
   detailAddress: string;
   job: string;
   period: string;
+  zipcode: string;
+  roadAddress: string;
 };
 
 type SeniorStep3Props = {
   state: Step3State;
   setState: React.Dispatch<React.SetStateAction<Step3State>>;
   onSubmit: () => void;
+  isLoading?: boolean;
 };
 
-const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
+const SeniorStep3 = ({
+  state,
+  setState,
+  onSubmit,
+  isLoading = false,
+}: SeniorStep3Props) => {
   const [jobOpen, setJobOpen] = useState(false);
   const [periodOpen, setPeriodOpen] = useState(false);
 
@@ -77,14 +85,36 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
     if (window.daum?.Postcode) {
       new window.daum.Postcode({
         oncomplete: function (data: any) {
-          setState((s) => ({ ...s, address: data.address }));
+          setState((s) => ({
+            ...s,
+            address: data.address,
+            zipcode: data.zonecode,
+            roadAddress: data.address,
+          }));
         },
       }).open();
     } else {
       alert(
-        '주소 검색 스크립트가 아직 로드되지 않았습니다. 잠시 후 다시 시도해주세요.'
+        '주소 검색 스크립트가 로드되지 않았습니다. 잠시 후 다시 시도해주세요.'
       );
     }
+  };
+
+  const handleSubmit = () => {
+    // 필수 입력 검증
+    if (
+      !state.age ||
+      !state.gender ||
+      !state.phone ||
+      !state.address ||
+      !state.job ||
+      !state.period
+    ) {
+      alert('모든 항목을 입력해주세요.');
+      return;
+    }
+
+    onSubmit();
   };
 
   return (
@@ -101,17 +131,20 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
           placeholder="어르신의 연세를 입력해주세요"
           value={state.age}
           onChange={(e) => setState((s) => ({ ...s, age: e.target.value }))}
+          type="number"
         />
         <div className="flex gap-2 w-full mb-3">
           <button
-            className={`${genderBtnClass} ${state.gender === '여성' ? 'border-[#08D485] text-[#08D485]' : 'text-[#c2c2c2]'}`}
-            onClick={() => setState((s) => ({ ...s, gender: '여성' }))}
+            className={`${genderBtnClass} ${state.gender === 'FEMALE' ? 'border-[#08D485] text-[#08D485]' : 'text-[#c2c2c2]'}`}
+            onClick={() => setState((s) => ({ ...s, gender: 'FEMALE' }))}
+            type="button"
           >
             여성
           </button>
           <button
-            className={`${genderBtnClass} ${state.gender === '남성' ? 'border-[#08D485] text-[#08D485]' : 'text-[#c2c2c2]'}`}
-            onClick={() => setState((s) => ({ ...s, gender: '남성' }))}
+            className={`${genderBtnClass} ${state.gender === 'MALE' ? 'border-[#08D485] text-[#08D485]' : 'text-[#c2c2c2]'}`}
+            onClick={() => setState((s) => ({ ...s, gender: 'MALE' }))}
+            type="button"
           >
             남성
           </button>
@@ -127,9 +160,7 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
             className={`${selectClass} w-[18.7rem] mb-0 ${state.address ? 'text-black' : 'text-[#c2c2c2]'}`}
             placeholder="거주지를 입력해주세요"
             value={state.address}
-            onChange={(e) =>
-              setState((s) => ({ ...s, address: e.target.value }))
-            }
+            readOnly
           />
           <button
             className="bg-[#08D485] w-[10rem] text-black rounded-[8px] py-[1.2rem] text-[1.6rem] font-medium h-[4.5rem]"
@@ -150,13 +181,15 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
         <div className="w-full text-left text-[#747474] font-semibold text-[1.6rem] mt-[1.4rem] mb-[1.4rem]">
           경력 사항
         </div>
+
+        {/* 직무 선택 */}
         <div className="flex w-full mb-3 gap-[6.5rem]">
           <div className="w-[4.5rem] text-[#747474] text-[1.6rem] mt-[1rem]">
             직무
           </div>
           <div className="flex-1 relative">
             <div
-              className={`${dropdownBoxClass} h-[4.5rem] ${jobOpen ? '' : ''}`}
+              className={`${dropdownBoxClass} h-[4.5rem]`}
               onClick={() => setJobOpen((open) => !open)}
             >
               <div
@@ -202,13 +235,15 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
             )}
           </div>
         </div>
+
+        {/* 경력 기간 선택 */}
         <div className="flex gap-[6.5rem] w-full">
           <div className="w-[4.5rem] text-[#747474] text-[1.6rem] mt-[1rem]">
             기간
           </div>
           <div className="flex-1 relative">
             <div
-              className={`${dropdownBoxClass} h-[4.5rem] ${periodOpen ? '' : ''}`}
+              className={`${dropdownBoxClass} h-[4.5rem]`}
               onClick={() => setPeriodOpen((open) => !open)}
             >
               <div
@@ -254,8 +289,12 @@ const SeniorStep3 = ({ state, setState, onSubmit }: SeniorStep3Props) => {
             )}
           </div>
         </div>
-        <NextButton className="!mt-[1.4rem]" onClick={onSubmit}>
-          회원가입 완료
+        <NextButton
+          className="!mt-[1.4rem]"
+          onClick={handleSubmit}
+          disabled={isLoading}
+        >
+          {isLoading ? '회원가입 중...' : '회원가입 완료'}
         </NextButton>
       </div>
     </div>

--- a/src/pages/Personal/hooks/useAuth.ts
+++ b/src/pages/Personal/hooks/useAuth.ts
@@ -5,12 +5,14 @@ import {
   verifyCode,
   checkUsernameAvailability,
   login,
+  signupProtector,
 } from '../apis/auth';
 import {
   SeniorSignupRequest,
   SendVerificationRequest,
   VerifyCodeRequest,
   LoginRequest,
+  ProtectorSignupRequest,
 } from '../types/auth';
 
 // 시니어 회원가입 훅
@@ -22,6 +24,19 @@ export const useSeniorSignup = () => {
     },
     onError: (error) => {
       console.error('회원가입 실패:', error);
+    },
+  });
+};
+
+// 보호자 회원가입 훅
+export const useProtectorSignup = () => {
+  return useMutation({
+    mutationFn: (data: ProtectorSignupRequest) => signupProtector(data),
+    onSuccess: (data) => {
+      console.log('보호자 회원가입 성공:', data);
+    },
+    onError: (error) => {
+      console.error('보호자 회원가입 실패:', error);
     },
   });
 };

--- a/src/pages/Personal/hooks/useAuth.ts
+++ b/src/pages/Personal/hooks/useAuth.ts
@@ -1,0 +1,64 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  signupSenior,
+  sendVerificationCode,
+  verifyCode,
+  checkUsernameAvailability,
+} from '../apis/auth';
+import {
+  SeniorSignupRequest,
+  SendVerificationRequest,
+  VerifyCodeRequest,
+} from '../types/auth';
+
+// 시니어 회원가입 훅
+export const useSeniorSignup = () => {
+  return useMutation({
+    mutationFn: (data: SeniorSignupRequest) => signupSenior(data),
+    onSuccess: (data) => {
+      console.log('회원가입 성공:', data);
+    },
+    onError: (error) => {
+      console.error('회원가입 실패:', error);
+    },
+  });
+};
+
+// 인증번호 발송 훅
+export const useSendVerificationCode = () => {
+  return useMutation({
+    mutationFn: (data: SendVerificationRequest) => sendVerificationCode(data),
+    onSuccess: (data) => {
+      console.log('인증번호 발송 성공:', data);
+    },
+    onError: (error) => {
+      console.error('인증번호 발송 실패:', error);
+    },
+  });
+};
+
+// 인증번호 확인 훅
+export const useVerifyCode = () => {
+  return useMutation({
+    mutationFn: (data: VerifyCodeRequest) => verifyCode(data),
+    onSuccess: (data) => {
+      console.log('인증번호 확인 성공:', data);
+    },
+    onError: (error) => {
+      console.error('인증번호 확인 실패:', error);
+    },
+  });
+};
+
+// 아이디 중복 확인 훅
+export const useCheckUsername = () => {
+  return useMutation({
+    mutationFn: (username: string) => checkUsernameAvailability(username),
+    onSuccess: (data) => {
+      console.log('아이디 확인 결과:', data);
+    },
+    onError: (error) => {
+      console.error('아이디 확인 실패:', error);
+    },
+  });
+}; 

--- a/src/pages/Personal/hooks/useAuth.ts
+++ b/src/pages/Personal/hooks/useAuth.ts
@@ -4,11 +4,13 @@ import {
   sendVerificationCode,
   verifyCode,
   checkUsernameAvailability,
+  login,
 } from '../apis/auth';
 import {
   SeniorSignupRequest,
   SendVerificationRequest,
   VerifyCodeRequest,
+  LoginRequest,
 } from '../types/auth';
 
 // 시니어 회원가입 훅
@@ -62,3 +64,10 @@ export const useCheckUsername = () => {
     },
   });
 }; 
+
+// 일반 로그인 훅
+export const useLogin = () => {
+  return useMutation({
+    mutationFn: (data: LoginRequest) => login(data)
+  })
+};

--- a/src/pages/Personal/types/auth.ts
+++ b/src/pages/Personal/types/auth.ts
@@ -75,3 +75,9 @@ export interface VerifyCodeRequest {
   phone: string;
   verificationCode: string;
 }
+
+// 일반 로그인
+export interface LoginRequest {
+  username: string;
+  password: string;
+}

--- a/src/pages/Personal/types/auth.ts
+++ b/src/pages/Personal/types/auth.ts
@@ -1,0 +1,77 @@
+export type Gender = 'MALE' | 'FEMALE';
+
+export type Job =
+  | 'HOUSEWIFE'
+  | 'EMPLOYEE'
+  | 'PUBLIC_OFFICER'
+  | 'PROFESSIONAL'
+  | 'ARTIST'
+  | 'BUSINESS_OWNER'
+  | 'ETC';
+
+export type ExperiencePeriod =
+  | 'LESS_THAN_6_MONTHS'
+  | 'SIX_MONTHS_TO_1_YEAR'
+  | 'ONE_TO_THREE_YEARS'
+  | 'THREE_TO_FIVE_YEARS'
+  | 'FIVE_TO_TEN_YEARS'
+  | 'OVER_TEN_YEARS';
+
+// 프로필
+export interface BaseSignupInfo {
+  username: string;
+  password: string;
+  name: string;
+  age: number;
+  gender: Gender;
+}
+
+// 주소 정보
+export interface AddressInfo {
+  zipcode: string;
+  roadAddress: string;
+  detailAddress?: string;
+}
+
+// 보호자 연결 여부
+export interface ProtectorConnectionInfo {
+  protectorId: number | null; // null이면 독립 가입
+  relation?: string; // protectorId가 있을 때만 필수
+}
+
+export interface ProfileInfo {
+  job: Job;
+  experiencePeriod: ExperiencePeriod;
+}
+
+// 시니어
+export interface SeniorSignupRequest
+  extends BaseSignupInfo,
+    ProfileInfo,
+    AddressInfo,
+    ProtectorConnectionInfo {
+  phoneNum: string;
+  providerType: string | null;
+  providerUserId: number | null;
+}
+
+// 보호자
+export interface ProtectorSignupRequest {
+  username: string;
+  password: string;
+  name: string;
+  phone: string;
+  providerType: string | null;
+  providerUserId: number | null;
+}
+
+// 인증 번호 발송
+export interface SendVerificationRequest {
+  phone: string;
+}
+
+// 인증 번호 확인
+export interface VerifyCodeRequest {
+  phone: string;
+  verificationCode: string;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -25,7 +25,7 @@ const AppRoutes = () => {
   return (
     <Routes>
       {/* 개인 버전 */}
-      <Route path="/personal" element={<PersonalHomePage />}></Route>
+      <Route path="/" element={<PersonalHomePage />}></Route>
       <Route path="/personal/join" element={<SignIn />}></Route>
       <Route path="/personal/join/senior" element={<SeniorSignIn />}></Route>
       <Route path="/personal/join/guardian" element={<CareSignIn />}></Route>

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -23,29 +23,31 @@ axiosInstance.interceptors.request.use(
   }
 );
 
-// 응답 인터셉터 - 토큰 저장 및 만료 처리
+// 응답 인터셉터 - 토큰 저장 및 만료 처리 (28-42번째 줄 수정)
 axiosInstance.interceptors.response.use(
   (response) => {
-    // 로그인 성공 시 accessToken만 저장 (refreshToken은 HttpOnly 쿠키로 자동 관리)
+    // 로그인 성공 시 accessToken만 저장
     if (response.config.url?.includes('/auth/login')) {
-      const { accessToken } = response.data;
+      
+      // result 안에 accessToken이 있는지 확인
+      const accessToken = response.data.result?.accessToken || response.data.accessToken;
       
       if (accessToken) {
         localStorage.setItem('accessToken', accessToken);
-        console.log('Access Token 저장됨');
+      } else {
+        console.error('accessToken을 찾을 수 없음:', response.data);
       }
     }
-    
-    // OAuth 토큰 교환 시에도 accessToken 저장
+
+    // OAuth 토큰 교환 시에도 동일하게 처리
     if (response.config.url?.includes('/token/exchange')) {
-      const { accessToken } = response.data;
-      
+      const accessToken = response.data.result?.accessToken || response.data.accessToken;
       if (accessToken) {
         localStorage.setItem('accessToken', accessToken);
         console.log('OAuth Access Token 저장됨');
       }
     }
-    
+
     return response;
   },
   

--- a/src/shared/apis/axiosInstance.ts
+++ b/src/shared/apis/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -8,11 +8,101 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-axiosInstance.interceptors.response.use(
-  (response) => {
-    return response;
+// 요청 시 accessToken 자동 삽입
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
   },
   (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터 - 토큰 저장 및 만료 처리
+axiosInstance.interceptors.response.use(
+  (response) => {
+    // 로그인 성공 시 accessToken만 저장 (refreshToken은 HttpOnly 쿠키로 자동 관리)
+    if (response.config.url?.includes('/auth/login')) {
+      const { accessToken } = response.data;
+      
+      if (accessToken) {
+        localStorage.setItem('accessToken', accessToken);
+        console.log('Access Token 저장됨');
+      }
+    }
+    
+    // OAuth 토큰 교환 시에도 accessToken 저장
+    if (response.config.url?.includes('/token/exchange')) {
+      const { accessToken } = response.data;
+      
+      if (accessToken) {
+        localStorage.setItem('accessToken', accessToken);
+        console.log('OAuth Access Token 저장됨');
+      }
+    }
+    
+    return response;
+  },
+  
+  async (error: AxiosError<any>) => {
+    const originalRequest = error.config as AxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    console.error('[axiosInstance] 응답 에러:', error.response?.data);
+
+    // accessToken 만료 에러 처리
+    if (
+      error.response?.status === 401 && 
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+
+      try {
+        console.log('[axiosInstance] 토큰 재발급 시도...');
+        
+        // 토큰 갱신
+        const response = await axiosInstance.post('/api/token/refresh', {});
+
+        // 새 accessToken 저장
+        const newAccessToken = response.data?.accessToken;
+        
+        if (!newAccessToken) {
+          throw new Error('새 액세스 토큰을 받지 못했습니다.');
+        }
+
+        localStorage.setItem('accessToken', newAccessToken);
+        console.log('[axiosInstance] 토큰 재발급 성공');
+
+        // 원래 요청에 새 토큰 적용
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        }
+
+        // 원래 요청 재시도
+        return axiosInstance(originalRequest);
+
+      } catch (refreshError) {
+        console.error('[axiosInstance] 토큰 재발급 실패:', refreshError);
+
+        // accessToken 제거
+        localStorage.removeItem('accessToken');
+
+        // 로그인 페이지로 리다이렉트
+        if (!window.location.pathname.includes('/login')) {
+          alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+          window.location.href = '/personal/login';
+        }
+
+        return Promise.reject(refreshError);
+      }
+    }
+
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #62 

## 📝 작업 내용

## **일반 유저의 로그인 및 회원가입 api 연동 진행**
- 시니어 회원가입
- 일반 로그인

- 보호자 대리 회원가입은 작성은 했는데, 살짝 오류가 있는 것 같아서 추후 수정해야할 것 같습니다. 

### 이 과정에서 다음과 같은 api가 추가 연동되었습니다.
- sms 인증번호 발송
- sms 인증번호 확인 
- 아이디 중복 확인
- 토큰 갱신
- Authorization Code로 토큰 교환

<br />

## 추가로 로그인 과정에 있어서 토큰 저장 및 검증에 대한 내용이 `axiosInstance`에 추가되었습니다.

### 토큰 관리 방식
- AccessToken: localStorage에 저장
- RefreshToken: HttpOnly 쿠키로 서버에서 관리

### 자동 처리
- 요청 시: axiosInstance가 자동으로 Authorization 헤더에 토큰 추가 (별도로 작성하실 필요가 없습니다.)
- 만료 시: 자동으로 토큰 갱신 후 재요청
- 실패 시: 자동 로그아웃 후 로그인 페이지로 이동

- 로그인 체크할 때 localStorage.getItem('accessToken') 사용
** localStorage는 실시간으로 변경을 감지하지 않으므로, 로그인/로그아웃 후 상태 업데이트가 필요할 수 있습니다.



<br />
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🖼️ 구현 화면

<br />
<!-- 애니메이션이 있다면 gif나 영상 첨부 해주세요  -->

## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
