### PR TITLE
[style] 헤더 토글 버튼 없는 버전 추가

### DIFF
--- a/src/pages/Company/CompanySignin.tsx
+++ b/src/pages/Company/CompanySignin.tsx
@@ -179,7 +179,7 @@ const CompanySignin = () => {
 
   return (
     <TopbarForLogin showToggle={false}>
-      <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
+      <div className="flex flex-col items-center w-full px-[3.3rem]">
         {/* 성공/에러 메시지 영역 완전 제거 */}
 
         <div className="w-[29.4rem]">

--- a/src/pages/Company/CompanySignin.tsx
+++ b/src/pages/Company/CompanySignin.tsx
@@ -178,7 +178,7 @@ const CompanySignin = () => {
   };
 
   return (
-    <TopbarForLogin>
+    <TopbarForLogin showToggle={false}>
       <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
         {/* 성공/에러 메시지 영역 완전 제거 */}
 

--- a/src/pages/Company/components/FindAccount/FindAccount.tsx
+++ b/src/pages/Company/components/FindAccount/FindAccount.tsx
@@ -9,7 +9,7 @@ const CompanyFindAccount = () => {
   const [activeTab, setActiveTab] = useState<TabType>('id');
 
   return (
-    <TopbarForLogin>
+    <TopbarForLogin showToggle={false}>
       <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
         <div className="w-[29.4rem]">
           {/* 헤더 */}

--- a/src/pages/Company/components/FindAccount/FindAccount.tsx
+++ b/src/pages/Company/components/FindAccount/FindAccount.tsx
@@ -10,7 +10,7 @@ const CompanyFindAccount = () => {
 
   return (
     <TopbarForLogin showToggle={false}>
-      <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
+      <div className="flex flex-col items-center w-full px-[3.3rem]">
         <div className="w-[29.4rem]">
           {/* 헤더 */}
           <div className="text-center mb-[3.1rem]">

--- a/src/pages/Personal/components/user/FindAccount/FindAccount.tsx
+++ b/src/pages/Personal/components/user/FindAccount/FindAccount.tsx
@@ -10,7 +10,7 @@ const FindAccount = () => {
 
   return (
     <TopbarForLogin showToggle={false}>
-      <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
+      <div className="flex flex-col items-center w-full px-[3.3rem]">
         <div className="w-[29.4rem]">
           {/* 헤더 */}
           <div className="text-center mb-[3.1rem]">

--- a/src/pages/Personal/components/user/FindAccount/FindAccount.tsx
+++ b/src/pages/Personal/components/user/FindAccount/FindAccount.tsx
@@ -9,7 +9,7 @@ const FindAccount = () => {
   const [activeTab, setActiveTab] = useState<TabType>('id');
 
   return (
-    <TopbarForLogin>
+    <TopbarForLogin showToggle={false}>
       <div className="flex flex-col items-center w-full pt-8 px-[3.3rem]">
         <div className="w-[29.4rem]">
           {/* 헤더 */}

--- a/src/pages/Personal/components/user/signIn/Care/CareSignIn.tsx
+++ b/src/pages/Personal/components/user/signIn/Care/CareSignIn.tsx
@@ -263,7 +263,7 @@ const CareSignIn = () => {
   };
 
   return (
-    <TopbarForLogin>
+    <TopbarForLogin showToggle={false}>
       {step === 1 && !isFromKakao && (
         <CareStep1
           state={step1State}

--- a/src/pages/Personal/components/user/signIn/Senior/SeniorSignIn.tsx
+++ b/src/pages/Personal/components/user/signIn/Senior/SeniorSignIn.tsx
@@ -134,7 +134,7 @@ const SeniorSignIn = () => {
 
   return (
     <div>
-      <TopbarForLogin />
+      <TopbarForLogin showToggle={false} />
 
       {step === 1 && !isFromKakao && (
         <SeniorStep1

--- a/src/shared/components/topbar/TopbarForLogin.tsx
+++ b/src/shared/components/topbar/TopbarForLogin.tsx
@@ -8,9 +8,13 @@ import CompanyMenu from './menu/company-menu/CompanyMenu';
 
 interface TopbarForLoginProps {
   children?: ReactNode;
+  showToggle?: boolean; // 토글바 표시 여부
 }
 
-const TopbarForLogin = ({ children }: TopbarForLoginProps) => {
+const TopbarForLogin = ({
+  children,
+  showToggle = true,
+}: TopbarForLoginProps) => {
   const location = useLocation();
 
   const version: 'personal' | 'company' = location.pathname.startsWith(
@@ -26,8 +30,6 @@ const TopbarForLogin = ({ children }: TopbarForLoginProps) => {
         <div className="flex justify-center">
           <div className="w-[318px] flex justify-between items-center bt-[2px] p-[4px]">
             <div className="relative">
-              {/* {version === 'personal' ? <PersonalMenu /> : <CompanyMenu />}
-              {version === 'personal' ? <QuestionButton /> : ''} */}
               {version === 'personal' ? (
                 <div className="flex justify-around items-start gap-[21px] opacity-0 pointer-events-none">
                   <PersonalMenu />
@@ -39,9 +41,12 @@ const TopbarForLogin = ({ children }: TopbarForLoginProps) => {
                 </div>
               )}
             </div>
-            <div>
-              <ToggleButton />
-            </div>
+            {/* 토글바 조건부 렌더링 */}
+            {showToggle && (
+              <div>
+                <ToggleButton />
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #91

## 📝 작업 내용

- 회원가입 및 계정찾기 플로우에서 헤더에 토글 버튼 없는 ui를 위해 props로 관리합니다.
- 기존 헤더는 상관없고, 토글 버튼이 없는 경우 `<TopbarForLogin showToggle={false}>`로 사용할 수 있습니다. 

<br />
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🖼️ 구현 화면
<img width="362" height="162" alt="image" src="https://github.com/user-attachments/assets/77c07ae0-ddd5-4bd3-8c75-78f94cfef6db" />

<br />
<!-- 애니메이션이 있다면 gif나 영상 첨부 해주세요  -->

## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
