### PR TITLE
[feat] 개인 신청서 추가 질문 없는 버전 제출 api 연결

### DIFF
--- a/src/pages/Personal/JobApplyDefaultForm.tsx
+++ b/src/pages/Personal/JobApplyDefaultForm.tsx
@@ -2,16 +2,35 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormField } from './types/jobs';
 import Topbar from '../../shared/components/topbar/Topbar';
-
+import { useSubmitApplication } from './hooks/useSubmitApplication';
 
 type Props = {
     formFields: FormField[];
     roadAddress: string;
+    jobPostId: number;
 };
 
-const JobApplyDefaultForm = ({ formFields, roadAddress }: Props) => {
+const JobApplyDefaultForm = ({ formFields, roadAddress, jobPostId }: Props) => {
     const [step, setStep] = useState<1 | 2>(1);
+    const { mutate: submitApplication, isPending } = useSubmitApplication();
+    const handleSubmit = () => {
+        const payload = {
+            jobPostId,
+            applicationStatus: "SUBMITTED" as const,
+            fieldAndAnswer: formFields.map((field) => ({
+                formFieldId: field.id,
+                fieldType: field.fieldType,
+                answer: field.answer ?? '',
+            })),
+        };
+
+        submitApplication(payload, {
+            onSuccess: () => setStep(2),
+            onError: () => alert('신청서 제출에 실패했습니다.'),
+        });
+    };
     const navigate = useNavigate();
+
     return (
         <Topbar>
             <div className="p-[13px]">
@@ -45,7 +64,8 @@ const JobApplyDefaultForm = ({ formFields, roadAddress }: Props) => {
                             </button>
                             <button
                                 className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-                                onClick={() => setStep(2)}
+                                onClick={handleSubmit}
+                                disabled={isPending}
                             >
                                 제출
                             </button>
@@ -57,7 +77,7 @@ const JobApplyDefaultForm = ({ formFields, roadAddress }: Props) => {
                     <>
                         <p className="text-[16px] text-[#747474] font-semibold mt-[27px]">신청 완료되었습니다</p>
 
-                        <button className="w-[294px] h-[45px] mt-[44px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
+                        <button className="w-[294px] h-[45px] mt-[44px] text-[16px] text-[#747474] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
                             {roadAddress}
                         </button>
 

--- a/src/pages/Personal/JobApplyDefaultForm.tsx
+++ b/src/pages/Personal/JobApplyDefaultForm.tsx
@@ -1,22 +1,93 @@
-import { FormField } from "./types/jobs";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FormField } from './types/jobs';
+import Topbar from '../../shared/components/topbar/Topbar';
+
 
 type Props = {
-  formFields: FormField[];
+    formFields: FormField[];
+    address: string;
 };
 
-const JobApplyDefaultForm = ({ formFields }: Props) => {
-  return (
-    <div>
-      <h2>기본 질문 신청서</h2>
-      {formFields.map((field) => (
-        <div key={field.id}>
-          <label>{field.fieldName}</label>
-          {/* type에 따라 컴포넌트 다르게 렌더링 가능 */}
-          <input type="text" className="border p-1" />
-        </div>
-      ))}
-    </div>
-  );
+const JobApplyDefaultForm = ({ formFields, address }: Props) => {
+    const [step, setStep] = useState<1 | 2>(1);
+    const navigate = useNavigate();
+    return (
+        <Topbar>
+            <div className="p-[13px]">
+                <h2 className="text-[20px] text-[#747474] font-semibold mt-[12px] text-center">신청서 작성</h2>
+
+                {step === 1 && (
+                    <>
+                        <p className="text-[16px] text-[#747474] font-semibold mt-[27px]">신청서에 추가할 항목이 없습니다.<br />제출하시겠습니까?</p>
+
+                        <button className="w-[294px] h-[45px] mt-[21px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
+                            {address}
+                        </button>
+
+                        <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
+                            <span className="text-[16px] text-[#414141]">
+                                기본 정보
+                            </span>
+                            <div className="mt-[14px] text-[14px] text-[#414141]">
+                                {formFields.map((field) => (
+                                    <div className="flex justify-between mb-[8px]" key={field.id}>
+                                        <span className="font-semibold">{field.fieldName}</span>
+                                        <span>{field.answer ?? '-'}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="flex justify-between gap-[13px] mt-[69px]">
+                            <button className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]">
+                                저장
+                            </button>
+                            <button
+                                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                                onClick={() => setStep(2)}
+                            >
+                                제출
+                            </button>
+                        </div>
+                    </>
+                )}
+
+                {step === 2 && (
+                    <>
+                        <p className="text-[16px] text-[#747474] font-semibold mt-[27px]">신청 완료되었습니다</p>
+
+                        <button className="w-[294px] h-[45px] mt-[44px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
+                            {address}
+                        </button>
+
+                        <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
+                            <span className="text-[16px] text-[#414141]">
+                                기본 정보
+                            </span>
+                            <div className="mt-[14px] text-[14px] text-[#414141]">
+                                {formFields.map((field) => (
+                                    <div className="flex justify-between mb-[8px]" key={field.id}>
+                                        <span className="font-semibold">{field.fieldName}</span>
+                                        <span>{field.answer ?? '-'}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <button
+                            className="w-full h-[45px] mt-[72px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                            onClick={() => {
+                                navigate('/')
+                            }}
+                        >
+                            홈으로
+                        </button>
+                    </>
+                )}
+            </div>
+        </Topbar>
+    );
 };
 
 export default JobApplyDefaultForm;

--- a/src/pages/Personal/JobApplyDefaultForm.tsx
+++ b/src/pages/Personal/JobApplyDefaultForm.tsx
@@ -6,10 +6,10 @@ import Topbar from '../../shared/components/topbar/Topbar';
 
 type Props = {
     formFields: FormField[];
-    address: string;
+    roadAddress: string;
 };
 
-const JobApplyDefaultForm = ({ formFields, address }: Props) => {
+const JobApplyDefaultForm = ({ formFields, roadAddress }: Props) => {
     const [step, setStep] = useState<1 | 2>(1);
     const navigate = useNavigate();
     return (
@@ -21,8 +21,8 @@ const JobApplyDefaultForm = ({ formFields, address }: Props) => {
                     <>
                         <p className="text-[16px] text-[#747474] font-semibold mt-[27px]">신청서에 추가할 항목이 없습니다.<br />제출하시겠습니까?</p>
 
-                        <button className="w-[294px] h-[45px] mt-[21px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
-                            {address}
+                        <button className="w-[294px] h-[45px] mt-[21px] text-[16px] text-[#747474] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
+                            {roadAddress}
                         </button>
 
                         <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
@@ -58,7 +58,7 @@ const JobApplyDefaultForm = ({ formFields, address }: Props) => {
                         <p className="text-[16px] text-[#747474] font-semibold mt-[27px]">신청 완료되었습니다</p>
 
                         <button className="w-[294px] h-[45px] mt-[44px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#747474]">
-                            {address}
+                            {roadAddress}
                         </button>
 
                         <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">

--- a/src/pages/Personal/JobApplyDefaultForm.tsx
+++ b/src/pages/Personal/JobApplyDefaultForm.tsx
@@ -1,0 +1,22 @@
+import { FormField } from "./types/jobs";
+
+type Props = {
+  formFields: FormField[];
+};
+
+const JobApplyDefaultForm = ({ formFields }: Props) => {
+  return (
+    <div>
+      <h2>기본 질문 신청서</h2>
+      {formFields.map((field) => (
+        <div key={field.id}>
+          <label>{field.fieldName}</label>
+          {/* type에 따라 컴포넌트 다르게 렌더링 가능 */}
+          <input type="text" className="border p-1" />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default JobApplyDefaultForm;

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -4,6 +4,7 @@ import { FormField } from "./types/jobs";
 type Props = {
     formFields: FormField[];
     roadAddress: string;
+    jobPostId: number;
 };
 
 const JobApplyExtendedForm = ({ formFields }: Props) => {

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -3,6 +3,7 @@ import { FormField } from "./types/jobs";
 
 type Props = {
     formFields: FormField[];
+    roadAddress: string;
 };
 
 const JobApplyExtendedForm = ({ formFields }: Props) => {

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -1,0 +1,23 @@
+import { FormField } from "./types/jobs";
+
+type Props = {
+  formFields: FormField[];
+};
+
+const JobApplyExtendedForm = ({ formFields }: Props) => {
+  return (
+    <div>
+      <h2>추가 질문 포함 신청서</h2>
+      {formFields.map((field) => (
+        <div key={field.id}>
+          <label>{field.fieldName}</label>
+          {field.fieldType === 'TEXT' && <input type="text" className="border p-1" />}
+          {field.fieldType === 'IMAGE' && <input type="file" />}
+          {/* CHOICE 타입 등은 나중에 확장 가능 */}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default JobApplyExtendedForm;

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -1,23 +1,26 @@
+import Topbar from "../../shared/components/topbar/Topbar";
 import { FormField } from "./types/jobs";
 
 type Props = {
-  formFields: FormField[];
+    formFields: FormField[];
 };
 
 const JobApplyExtendedForm = ({ formFields }: Props) => {
-  return (
-    <div>
-      <h2>추가 질문 포함 신청서</h2>
-      {formFields.map((field) => (
-        <div key={field.id}>
-          <label>{field.fieldName}</label>
-          {field.fieldType === 'TEXT' && <input type="text" className="border p-1" />}
-          {field.fieldType === 'IMAGE' && <input type="file" />}
-          {/* CHOICE 타입 등은 나중에 확장 가능 */}
-        </div>
-      ))}
-    </div>
-  );
+    return (
+        <Topbar>
+            <div>
+                <h2>추가 질문 포함 신청서</h2>
+                {formFields.map((field) => (
+                    <div key={field.id}>
+                        <label>{field.fieldName}</label>
+                        {field.fieldType === 'TEXT' && <input type="text" className="border p-1" />}
+                        {field.fieldType === 'IMAGE' && <input type="file" />}
+                        {/* CHOICE 타입 등은 나중에 확장 가능 */}
+                    </div>
+                ))}
+            </div>
+        </Topbar>
+    );
 };
 
 export default JobApplyExtendedForm;

--- a/src/pages/Personal/JobApplyPageTest.tsx
+++ b/src/pages/Personal/JobApplyPageTest.tsx
@@ -1,0 +1,29 @@
+import { useParams } from 'react-router-dom';
+import { useFormFields } from './hooks/useFormField';
+import JobApplyExtendedForm from './JobApplyExtendedForm';
+import JobApplyDefaultForm from './JobApplyDefaultForm';
+
+const JobApplyPageTest = () => {
+  const { jobId } = useParams();
+  const id = Number(jobId);
+
+  const { data, isLoading, isError } = useFormFields(id);
+
+  if (isLoading) return <div className="p-4">로딩 중입니다...</div>;
+  if (isError || !data) return <div className="p-4">에러가 발생했습니다.</div>;
+
+  const formFieldList = data.formFieldList;
+  const hasExtraQuestions = formFieldList.length > 4;
+
+  return (
+    <>
+      {hasExtraQuestions ? (
+        <JobApplyExtendedForm formFields={formFieldList} />
+      ) : (
+        <JobApplyDefaultForm formFields={formFieldList} />
+      )}
+    </>
+  );
+};
+
+export default JobApplyPageTest;

--- a/src/pages/Personal/JobApplyPageTest.tsx
+++ b/src/pages/Personal/JobApplyPageTest.tsx
@@ -20,9 +20,9 @@ const JobApplyPageTest = () => {
     const roadAddress = jobDetail.roadAddress ?? '주소 없음';
 
     return hasExtraQuestions ? (
-        <JobApplyExtendedForm formFields={formFieldList} roadAddress={roadAddress} />
+        <JobApplyExtendedForm formFields={formFieldList} roadAddress={roadAddress} jobPostId={id} />
     ) : (
-        <JobApplyDefaultForm formFields={formFieldList} roadAddress={roadAddress} />
+        <JobApplyDefaultForm formFields={formFieldList} roadAddress={roadAddress} jobPostId={id} />
     );
 };
 

--- a/src/pages/Personal/JobApplyPageTest.tsx
+++ b/src/pages/Personal/JobApplyPageTest.tsx
@@ -1,29 +1,29 @@
 import { useParams } from 'react-router-dom';
+import { useJobDetail } from './hooks/useDetail';
 import { useFormFields } from './hooks/useFormField';
 import JobApplyExtendedForm from './JobApplyExtendedForm';
 import JobApplyDefaultForm from './JobApplyDefaultForm';
 
 const JobApplyPageTest = () => {
-  const { jobId } = useParams();
-  const id = Number(jobId);
+    const { jobId } = useParams();
+    const id = Number(jobId);
 
-  const { data, isLoading, isError } = useFormFields(id);
+    const { data: formData, isLoading: isLoadingForm, isError: isErrorForm } = useFormFields(id);
+    const { data: jobDetail, isLoading: isLoadingDetail, isError: isErrorDetail } = useJobDetail(id);
 
-  if (isLoading) return <div className="p-4">로딩 중입니다...</div>;
-  if (isError || !data) return <div className="p-4">에러가 발생했습니다.</div>;
+    if (isLoadingForm || isLoadingDetail) return <div>로딩 중...</div>;
+    if (!formData || !jobDetail || isErrorForm || isErrorDetail) return <div>에러 발생</div>;
 
-  const formFieldList = data.formFieldList;
-  const hasExtraQuestions = formFieldList.length > 4;
+    const formFieldList = formData.formFieldList;
+    const hasExtraQuestions = formFieldList.length > 4;
 
-  return (
-    <>
-      {hasExtraQuestions ? (
-        <JobApplyExtendedForm formFields={formFieldList} />
-      ) : (
-        <JobApplyDefaultForm formFields={formFieldList} />
-      )}
-    </>
-  );
+    const roadAddress = jobDetail.roadAddress ?? '주소 없음';
+
+    return hasExtraQuestions ? (
+        <JobApplyExtendedForm formFields={formFieldList} roadAddress={roadAddress} />
+    ) : (
+        <JobApplyDefaultForm formFields={formFieldList} roadAddress={roadAddress} />
+    );
 };
 
 export default JobApplyPageTest;

--- a/src/pages/Personal/apis/jobapi.ts
+++ b/src/pages/Personal/apis/jobapi.ts
@@ -131,3 +131,16 @@ export const apiSearchJobs = (body: SearchJobRequest) => {
     body
   );
 };
+//신청서 폼 필드 타입 정의
+export async function getResult<T>(
+  url: string,
+  params?: Record<string, any>
+): Promise<T> {
+  const res = await axiosInstance.get<ApiEnvelope<T>>(url, {
+    params,
+  });
+  if (!res.data.isSuccess || !res.data.result) {
+    throw new Error(res.data.message ?? 'API 요청 실패');
+  }
+  return res.data.result;
+}

--- a/src/pages/Personal/apis/jobapplicationapi.tsx
+++ b/src/pages/Personal/apis/jobapplicationapi.tsx
@@ -1,0 +1,8 @@
+import axiosInstance from '../../../shared/apis/axiosInstance';
+import { PostApplicationDirectRequest } from '../types/jobapplication';
+
+// 신청서 제출버튼 시 사용하는 타입 정의
+export const apiPostApplicationDirect = async (body: PostApplicationDirectRequest) => {
+  const res = await axiosInstance.post('/api/applications/direct', body);
+  return res.data;
+};

--- a/src/pages/Personal/hooks/useFormField.tsx
+++ b/src/pages/Personal/hooks/useFormField.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getResult } from '../apis/jobapi';
+import { FormFieldListResponse } from '../types/jobs';
+
+
+export function useFormFields(jobPostId: number) {
+  return useQuery({
+    queryKey: ['formFields', jobPostId],
+    queryFn: () =>
+      getResult<FormFieldListResponse>(
+        `/api/job/${jobPostId}/questions/direct`
+      ),
+    enabled: !!jobPostId,
+    staleTime: 1000 * 60,
+  });
+}

--- a/src/pages/Personal/hooks/useSubmitApplication.tsx
+++ b/src/pages/Personal/hooks/useSubmitApplication.tsx
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { PostApplicationDirectRequest } from '../types/jobapplication';
+import { apiPostApplicationDirect } from '../apis/jobapplicationapi';
+
+export function useSubmitApplication() {
+  return useMutation({
+    mutationFn: (body: PostApplicationDirectRequest) =>
+      apiPostApplicationDirect(body),
+  });
+}

--- a/src/pages/Personal/types/jobapplication.ts
+++ b/src/pages/Personal/types/jobapplication.ts
@@ -1,0 +1,23 @@
+// 신청서 제출버튼 시 사용하는 타입 정의
+export type TextAnswer = {
+  formFieldId: number;
+  fieldType: 'TEXT' | 'IMAGE';
+  answer: string;
+};
+
+export type ImageAnswer = {
+  formFieldId: number;
+  fieldType: 'IMAGE';
+  answer: {
+    keyName: string;
+    originalFileName: string;
+  }[];
+};
+
+export type FieldAndAnswer = TextAnswer | ImageAnswer;
+
+export type PostApplicationDirectRequest = {
+  jobPostId: number;
+  applicationStatus: 'NON_STARTED' | 'SUBMITTED';
+  fieldAndAnswer: FieldAndAnswer[];
+};

--- a/src/pages/Personal/types/jobs.ts
+++ b/src/pages/Personal/types/jobs.ts
@@ -139,3 +139,13 @@ export type SearchJobResponse = {
   totalCount: number;
   hasNext: boolean;
 };
+//신청서 폼 필드 타입 정의
+export type FormField = {
+  id: number;
+  fieldName: string;
+  fieldType: 'TEXT' | 'IMAGE' ;
+  answer?: string;
+};
+export type FormFieldListResponse = {
+  formFieldList: FormField[];
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -47,6 +47,7 @@ import RepostStep2 from '../pages/Company/my/RePostStep2';
 import SeniorExtraInfo from '../pages/Personal/my/cares/care-seniors/SeniorExtraInfo';
 import SeniorExtraInfoEdit from '../pages/Personal/my/cares/care-seniors/SeniorExtraInfoEdit';
 import ClosedJobRepostDetail from '../pages/Company/my/ClosedJobRepostDetail';
+import JobApplyPageTest from '../pages/Personal/JobApplyPageTest';
 
 const AppRoutes = () => {
   return (
@@ -68,7 +69,7 @@ const AppRoutes = () => {
       ></Route>
       <Route
         path="/personal/jobs/recommend/:jobId/apply"
-        element={<JobApplyPage />}
+        element={<JobApplyPageTest />}
       ></Route>
       <Route
         path="/personal/jobs/recommend/:jobId/apply/question"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #163 

## 📝 작업 내용

- 개인 신청서 추가 질문 없는 경우 기본 정보만 가지고 post 되도록 api 연결.
- page는 jobapplyPageTest
- 분기 page JobApplyDefaultForm => 추가 질문 없는 부분
- 분기 page JobApplyExtendedForm => 추가 질문 있는 부분'
- jobapplication 파일 => 타입 정의 파일
- jobapplicationapi 파일 => 관련 api 연결 함수 정의 파일
- 사용은 훅을 만들어서 ui에 연결

<br />
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🖼️ 구현 화면

<br />
<!-- 애니메이션이 있다면 gif나 영상 첨부 해주세요  -->

## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
