### PR TITLE
[feat] 개인 일자리 신청 폼 ui 구현

### DIFF
--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -3,236 +3,263 @@ import { useNavigate } from 'react-router-dom';
 import Topbar from '../../shared/components/topbar/Topbar';
 import { FormField } from './types/jobs';
 
-// Step 상태 타입
 type Step = 'text' | 'image' | 'done';
 
 type Props = {
-  formFields: FormField[];
-  roadAddress: string;
-  jobPostId: number;
+    formFields: FormField[];
+    roadAddress: string;
+    jobPostId: number;
 };
 
 const JobApplyExtendedForm = ({ formFields, roadAddress, jobPostId }: Props) => {
-  const navigate = useNavigate();
-  const additionalFields = useMemo(() => formFields.slice(4), [formFields]);
+    const navigate = useNavigate();
+    const additionalFields = useMemo(() => formFields.slice(4), [formFields]);
 
-  const [answers, setAnswers] = useState<Record<number, string>>({});
-  const [finalCertFileName, setFinalCertFileName] = useState('');
+    const [answers, setAnswers] = useState<Record<number, string>>({});
+    const [finalCertFileName, setFinalCertFileName] = useState('');
 
-  const [currentStepIndex, setCurrentStepIndex] = useState(0);
-  const [submitted, setSubmitted] = useState(false);
+    const [currentStepIndex, setCurrentStepIndex] = useState(0);
+    const [submitted, setSubmitted] = useState(false);
 
-  const typeToStep = (t: FormField['fieldType']): Exclude<Step, 'done'> =>
-    t === 'IMAGE' ? 'image' : 'text';
+    const typeToStep = (t: FormField['fieldType']): Exclude<Step, 'done'> =>
+        t === 'IMAGE' ? 'image' : 'text';
 
-  const initialStep: Step =
-    additionalFields.length === 0 ? 'done' : typeToStep(additionalFields[0].fieldType);
+    const initialStep: Step =
+        additionalFields.length === 0 ? 'done' : typeToStep(additionalFields[0].fieldType);
 
-  const [step, setStep] = useState<Step>(initialStep);
+    const [step, setStep] = useState<Step>(initialStep);
 
-  const currentField = additionalFields[currentStepIndex];
-  const isFirst = currentStepIndex === 0;
-  const isLast = currentStepIndex === additionalFields.length - 1;
+    const currentField = additionalFields[currentStepIndex];
+    const isFirst = currentStepIndex === 0;
+    const isLast = currentStepIndex === additionalFields.length - 1;
 
-  const handleTextChange = (value: string) => {
-    if (!currentField) return;
-    setAnswers((prev) => ({ ...prev, [currentField.id]: value }));
-  };
+    const handleTextChange = (value: string) => {
+        if (!currentField) return;
+        setAnswers((prev) => ({ ...prev, [currentField.id]: value }));
+    };
 
-  const handleImageAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!currentField) return;
-    const file = e.target.files?.[0];
-    if (file) {
-      setAnswers((prev) => ({ ...prev, [currentField.id]: file.name }));
+    const handleImageAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (!currentField) return;
+        const file = e.target.files?.[0];
+        if (file) {
+            setAnswers((prev) => ({ ...prev, [currentField.id]: file.name }));
+        }
+    };
+
+    const handleFinalCertChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) setFinalCertFileName(file.name);
+    };
+
+    const goPrev = () => {
+        if (isFirst) return;
+        const prevIndex = currentStepIndex - 1;
+        setCurrentStepIndex(prevIndex);
+        setStep(typeToStep(additionalFields[prevIndex].fieldType));
+    };
+
+    const goNext = () => {
+        if (!isLast) {
+            const nextIndex = currentStepIndex + 1;
+            setCurrentStepIndex(nextIndex);
+            setStep(typeToStep(additionalFields[nextIndex].fieldType));
+        } else {
+            setStep('done');
+        }
+    };
+
+    const handleSubmit = () => {
+        console.log('최종 제출 데이터:', {
+            jobPostId,
+            roadAddress,
+            answers,
+            finalCertFileName,
+        });
+        setSubmitted(true);
+        setStep('done');
+    };
+
+    // -------------------- DONE 화면 --------------------
+    if (step === 'done') {
+        return (
+            <Topbar>
+                <div className="p-[13px]">
+                    <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+                        신청서 작성
+                    </h2>
+                    <h2 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+                        {submitted ? '신청 완료되었습니다' : '신청 완료 전 마지막으로 신청서를 확인하세요'}
+                    </h2>
+
+                    <div className="mt-[40px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+                        <p>{roadAddress}</p>
+                    </div>
+                    <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
+                        <span className="text-[16px] text-[#414141]">기본 정보</span>
+                        <div className="mt-[14px] text-[14px] text-[#414141]">
+                            {formFields.map((field) => (
+                                <div className="flex justify-between mb-[8px]" key={field.id}>
+                                    <span className="font-semibold">{field.fieldName}</span>
+                                    <span>{field.answer ?? '-'}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {additionalFields.map((field) => (
+                        <div key={field.id} className="mt-[24px]">
+                            <div className="w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+                                {field.fieldName}
+                            </div>
+                            <div className="w-full border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] mt-[21px]">
+                                {field.fieldType === 'TEXT' ? (
+                                    <p className="text-[14px] whitespace-pre-wrap">
+                                        {answers[field.id] ?? <span className="text-gray-400">미작성</span>}
+                                    </p>
+                                ) : (
+                                    <div className="flex items-center gap-2">
+                                        <p className="text-[14px]">{answers[field.id]}</p>
+                                        {!submitted && (
+                                            <input
+                                                type="file"
+                                                onChange={handleImageAnswerChange}
+                                                className="ml-auto"
+                                            />
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+
+                    <div className="mt-[39px]">
+                        <label className="block mb-1 text-[14px] text-[#747474]">
+                            {currentField?.fieldName || '자격증 이미지'}
+                        </label>
+                        <input
+                            type="file"
+                            onChange={handleFinalCertChange}
+                            disabled={submitted}
+                        />
+                        {finalCertFileName && <p className="mt-2">{finalCertFileName}</p>}
+                    </div>
+
+                    {submitted ? (
+                        <button
+                            onClick={() => navigate('/')}
+                            className="w-full h-[45px] mt-[24px] text-[16px] bg-[#08D485] text-black rounded-[8px]"
+                        >
+                            홈으로
+                        </button>
+                    ) : (
+                        <div className="flex justify-between gap-[13px] mt-[24px]">
+                            <button
+                                onClick={() => {
+                                    if (additionalFields.length > 0) {
+                                        setCurrentStepIndex(additionalFields.length - 1);
+                                        setStep(typeToStep(additionalFields[additionalFields.length - 1].fieldType));
+                                    }
+                                }}
+                                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]"
+                            >
+                                임시 저장
+                            </button>
+                            <button
+                                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                                onClick={handleSubmit}
+                            >
+                                제출
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </Topbar>
+        );
     }
-  };
 
-  const handleFinalCertChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) setFinalCertFileName(file.name);
-  };
+    // -------------------- TEXT 화면 --------------------
+    if (step === 'text') {
+        return (
+            <Topbar>
+                <div className="p-[13px]">
+                    <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+                        신청서 작성
+                    </h2>
 
-  const goPrev = () => {
-    if (isFirst) return;
-    const prevIndex = currentStepIndex - 1;
-    setCurrentStepIndex(prevIndex);
-    setStep(typeToStep(additionalFields[prevIndex].fieldType));
-  };
+                    <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+                        {currentField?.fieldName}
+                    </div>
 
-  const goNext = () => {
-    if (!isLast) {
-      const nextIndex = currentStepIndex + 1;
-      setCurrentStepIndex(nextIndex);
-      setStep(typeToStep(additionalFields[nextIndex].fieldType));
-    } else {
-      setStep('done');
+                    <input
+                        type="text"
+                        className="mt-[16px] border p-2 w-full"
+                        value={currentField ? answers[currentField.id] || '' : ''}
+                        onChange={(e) => handleTextChange(e.target.value)}
+                        placeholder="내용을 입력하세요"
+                    />
+
+                    <div className="flex justify-between gap-[13px] mt-[32px]">
+                        <button
+                            onClick={goPrev}
+                            disabled={isFirst}
+                            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+                        >
+                            이전
+                        </button>
+                        <button
+                            onClick={goNext}
+                            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                        >
+                            {isLast ? '다음' : '다음'}
+                        </button>
+                    </div>
+                </div>
+            </Topbar>
+        );
     }
-  };
 
-  const handleSubmit = () => {
-    console.log('최종 제출 데이터:', {
-      jobPostId,
-      roadAddress,
-      answers,
-      finalCertFileName,
-    });
-    setSubmitted(true);
-    setStep('done');
-  };
-
-  // -------------------- DONE 화면 --------------------
-  if (step === 'done') {
+    // -------------------- IMAGE 화면 --------------------
     return (
-      <Topbar>
-        <div className="p-[13px]">
-          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-            신청서 작성
-          </h2>
-          <h2 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
-            {submitted ? '신청 완료되었습니다' : '신청 완료 전 마지막으로 신청서를 확인하세요'}
-          </h2>
+        <Topbar>
+            <div className="p-[13px]">
+                <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+                    신청서 작성
+                </h2>
+                <h3 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+                    증빙자료 사진 첨부가 필요합니다
+                </h3>
 
-          <div className="mt-[40px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-            <p>{roadAddress}</p>
-          </div>
+                <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+                    {currentField?.fieldName}
+                </div>
 
-          <div className="border p-4 mt-[24px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] ">
-            {additionalFields.map((field) => (
-              <div key={field.id} className="mb-3">
-                <p className="font-medium">{field.fieldName}</p>
-                <p className="text-[14px] break-words">
-                  {answers[field.id] ?? <span className="text-gray-400">미작성</span>}
-                </p>
-              </div>
-            ))}
-          </div>
+                <input
+                    type="file"
+                    className="mt-[16px] p-4 w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000] flex items-center justify-center"
+                    onChange={handleImageAnswerChange}
+                />
+                {currentField && answers[currentField.id] && (
+                    <p className="mt-2 text-[14px]">{answers[currentField.id]}</p>
+                )}
 
-          <div className="mt-[39px]">
-            <label className="block mb-1 text-[14px] text-[#747474]">사회복지 자격증 이미지</label>
-            <input
-              type="file"
-              onChange={handleFinalCertChange}  
-              disabled={submitted}
-            />
-            {finalCertFileName && <p className="mt-2">{finalCertFileName}</p>}
-          </div>
-
-          {submitted ? (
-            <button
-              onClick={() => navigate('/')}
-              className="w-full h-[45px] mt-[24px] text-[16px] bg-[#08D485] text-black rounded-[8px]"
-            >
-              홈으로
-            </button>
-          ) : (
-            <div className="flex justify-between gap-[13px] mt-[24px]">
-              <button
-                onClick={() => {
-                  if (additionalFields.length > 0) {
-                    setCurrentStepIndex(additionalFields.length - 1);
-                    setStep(typeToStep(additionalFields[additionalFields.length - 1].fieldType));
-                  }
-                }}
-                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]"
-              >
-                임시 저장
-              </button>
-              <button
-                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-                onClick={handleSubmit}
-              >
-                제출
-              </button>
+                <div className="flex justify-between gap-[13px] mt-[255px]">
+                    <button
+                        onClick={goPrev}
+                        disabled={isFirst}
+                        className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+                    >
+                        이전
+                    </button>
+                    <button
+                        onClick={goNext}
+                        className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                    >
+                        {isLast ? '다음' : '다음'}
+                    </button>
+                </div>
             </div>
-          )}
-        </div>
-      </Topbar>
+        </Topbar>
     );
-  }
-
-  // -------------------- TEXT 화면 --------------------
-  if (step === 'text') {
-    return (
-      <Topbar>
-        <div className="p-[13px]">
-          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-            신청서 작성
-          </h2>
-
-          <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-            {currentField?.fieldName}
-          </div>
-
-          <input
-            type="text"
-            className="mt-[16px] border p-2 w-full"
-            value={currentField ? answers[currentField.id] || '' : ''}
-            onChange={(e) => handleTextChange(e.target.value)}
-            placeholder="내용을 입력하세요"
-          />
-
-          <div className="flex justify-between gap-[13px] mt-[32px]">
-            <button
-              onClick={goPrev}
-              disabled={isFirst}
-              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
-            >
-              이전
-            </button>
-            <button
-              onClick={goNext}
-              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-            >
-              {isLast ? '다음' : '다음'}
-            </button>
-          </div>
-        </div>
-      </Topbar>
-    );
-  }
-
-  // -------------------- IMAGE 화면 --------------------
-  return (
-    <Topbar>
-      <div className="p-[13px]">
-        <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-          신청서 작성
-        </h2>
-        <h3 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
-          증빙자료 사진 첨부가 필요합니다
-        </h3>
-
-        <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-          {currentField?.fieldName}
-        </div>
-
-        <input
-          type="file"
-          className="mt-[16px] p-4 w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000] flex items-center justify-center"
-          onChange={handleImageAnswerChange}
-        />
-        {currentField && answers[currentField.id] && (
-          <p className="mt-2 text-[14px]">{answers[currentField.id]}</p>
-        )}
-
-        <div className="flex justify-between gap-[13px] mt-[255px]">
-          <button
-            onClick={goPrev}
-            disabled={isFirst}
-            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
-          >
-            이전
-          </button>
-          <button
-            onClick={goNext}
-            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-          >
-            {isLast ? '다음' : '다음'}
-          </button>
-        </div>
-      </div>
-    </Topbar>
-  );
 };
 
 export default JobApplyExtendedForm;

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -6,260 +6,274 @@ import { FormField } from './types/jobs';
 type Step = 'text' | 'image' | 'done';
 
 type Props = {
-    formFields: FormField[];
-    roadAddress: string;
-    jobPostId: number;
+  formFields: FormField[];
+  roadAddress: string;
+  jobPostId: number;
 };
 
-const JobApplyExtendedForm = ({ formFields, roadAddress, jobPostId }: Props) => {
-    const navigate = useNavigate();
-    const additionalFields = useMemo(() => formFields.slice(4), [formFields]);
+const JobApplyExtendedForm = ({
+  formFields,
+  roadAddress,
+  jobPostId,
+}: Props) => {
+  const navigate = useNavigate();
+  const additionalFields = useMemo(() => formFields.slice(4), [formFields]);
 
-    const [answers, setAnswers] = useState<Record<number, string>>({});
-    const [finalCertFileName, setFinalCertFileName] = useState('');
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [finalCertFileName, setFinalCertFileName] = useState('');
 
-    const [currentStepIndex, setCurrentStepIndex] = useState(0);
-    const [submitted, setSubmitted] = useState(false);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [submitted, setSubmitted] = useState(false);
 
-    const typeToStep = (t: FormField['fieldType']): Exclude<Step, 'done'> =>
-        t === 'IMAGE' ? 'image' : 'text';
+  const typeToStep = (t: FormField['fieldType']): Exclude<Step, 'done'> =>
+    t === 'IMAGE' ? 'image' : 'text';
 
-    const initialStep: Step =
-        additionalFields.length === 0 ? 'done' : typeToStep(additionalFields[0].fieldType);
+  const initialStep: Step =
+    additionalFields.length === 0
+      ? 'done'
+      : typeToStep(additionalFields[0].fieldType);
 
-    const [step, setStep] = useState<Step>(initialStep);
+  const [step, setStep] = useState<Step>(initialStep);
 
-    const currentField = additionalFields[currentStepIndex];
-    const isFirst = currentStepIndex === 0;
-    const isLast = currentStepIndex === additionalFields.length - 1;
+  const currentField = additionalFields[currentStepIndex];
+  const isFirst = currentStepIndex === 0;
+  const isLast = currentStepIndex === additionalFields.length - 1;
 
-    const handleTextChange = (value: string) => {
-        if (!currentField) return;
-        setAnswers((prev) => ({ ...prev, [currentField.id]: value }));
-    };
+  const handleTextChange = (value: string) => {
+    if (!currentField) return;
+    setAnswers((prev) => ({ ...prev, [currentField.id]: value }));
+  };
 
-    const handleImageAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (!currentField) return;
-        const file = e.target.files?.[0];
-        if (file) {
-            setAnswers((prev) => ({ ...prev, [currentField.id]: file.name }));
-        }
-    };
-
-    const handleFinalCertChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (file) setFinalCertFileName(file.name);
-    };
-
-    const goPrev = () => {
-        if (isFirst) return;
-        const prevIndex = currentStepIndex - 1;
-        setCurrentStepIndex(prevIndex);
-        setStep(typeToStep(additionalFields[prevIndex].fieldType));
-    };
-
-    const goNext = () => {
-        if (!isLast) {
-            const nextIndex = currentStepIndex + 1;
-            setCurrentStepIndex(nextIndex);
-            setStep(typeToStep(additionalFields[nextIndex].fieldType));
-        } else {
-            setStep('done');
-        }
-    };
-
-    const handleSubmit = () => {
-        console.log('최종 제출 데이터:', {
-            jobPostId,
-            roadAddress,
-            answers,
-            finalCertFileName,
-        });
-        setSubmitted(true);
-        setStep('done');
-    };
-
-    // -------------------- DONE 화면 --------------------
-    if (step === 'done') {
-        return (
-            <Topbar>
-                <div className="p-[13px]">
-                    <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-                        신청서 작성
-                    </h2>
-                    <h2 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
-                        {submitted ? '신청 완료되었습니다' : '신청 완료 전 마지막으로 신청서를 확인하세요'}
-                    </h2>
-
-                    <div className="mt-[40px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-                        <p>{roadAddress}</p>
-                    </div>
-                    <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
-                        <span className="text-[16px] text-[#414141]">기본 정보</span>
-                        <div className="mt-[14px] text-[14px] text-[#414141]">
-                            {formFields.map((field) => (
-                                <div className="flex justify-between mb-[8px]" key={field.id}>
-                                    <span className="font-semibold">{field.fieldName}</span>
-                                    <span>{field.answer ?? '-'}</span>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-
-                    {additionalFields.map((field) => (
-                        <div key={field.id} className="mt-[24px]">
-                            <div className="w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-                                {field.fieldName}
-                            </div>
-                            <div className="w-full border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] mt-[21px]">
-                                {field.fieldType === 'TEXT' ? (
-                                    <p className="text-[14px] whitespace-pre-wrap">
-                                        {answers[field.id] ?? <span className="text-gray-400">미작성</span>}
-                                    </p>
-                                ) : (
-                                    <div className="flex items-center gap-2">
-                                        <p className="text-[14px]">{answers[field.id]}</p>
-                                        {!submitted && (
-                                            <input
-                                                type="file"
-                                                onChange={handleImageAnswerChange}
-                                                className="ml-auto"
-                                            />
-                                        )}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    ))}
-
-                    <div className="mt-[39px]">
-                        <label className="block mb-1 text-[14px] text-[#747474]">
-                            {currentField?.fieldName || '자격증 이미지'}
-                        </label>
-                        <input
-                            type="file"
-                            onChange={handleFinalCertChange}
-                            disabled={submitted}
-                        />
-                        {finalCertFileName && <p className="mt-2">{finalCertFileName}</p>}
-                    </div>
-
-                    {submitted ? (
-                        <button
-                            onClick={() => navigate('/')}
-                            className="w-full h-[45px] mt-[24px] text-[16px] bg-[#08D485] text-black rounded-[8px]"
-                        >
-                            홈으로
-                        </button>
-                    ) : (
-                        <div className="flex justify-between gap-[13px] mt-[24px]">
-                            <button
-                                onClick={() => {
-                                    if (additionalFields.length > 0) {
-                                        setCurrentStepIndex(additionalFields.length - 1);
-                                        setStep(typeToStep(additionalFields[additionalFields.length - 1].fieldType));
-                                    }
-                                }}
-                                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]"
-                            >
-                                임시 저장
-                            </button>
-                            <button
-                                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-                                onClick={handleSubmit}
-                            >
-                                제출
-                            </button>
-                        </div>
-                    )}
-                </div>
-            </Topbar>
-        );
+  const handleImageAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!currentField) return;
+    const file = e.target.files?.[0];
+    if (file) {
+      setAnswers((prev) => ({ ...prev, [currentField.id]: file.name }));
     }
+  };
 
-    // -------------------- TEXT 화면 --------------------
-    if (step === 'text') {
-        return (
-            <Topbar>
-                <div className="p-[13px]">
-                    <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-                        신청서 작성
-                    </h2>
+  const handleFinalCertChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setFinalCertFileName(file.name);
+  };
 
-                    <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-                        {currentField?.fieldName}
-                    </div>
+  const goPrev = () => {
+    if (isFirst) return;
+    const prevIndex = currentStepIndex - 1;
+    setCurrentStepIndex(prevIndex);
+    setStep(typeToStep(additionalFields[prevIndex].fieldType));
+  };
 
-                    <input
-                        type="text"
-                        className="mt-[16px] border p-2 w-full"
-                        value={currentField ? answers[currentField.id] || '' : ''}
-                        onChange={(e) => handleTextChange(e.target.value)}
-                        placeholder="내용을 입력하세요"
-                    />
-
-                    <div className="flex justify-between gap-[13px] mt-[32px]">
-                        <button
-                            onClick={goPrev}
-                            disabled={isFirst}
-                            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
-                        >
-                            이전
-                        </button>
-                        <button
-                            onClick={goNext}
-                            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-                        >
-                            {isLast ? '다음' : '다음'}
-                        </button>
-                    </div>
-                </div>
-            </Topbar>
-        );
+  const goNext = () => {
+    if (!isLast) {
+      const nextIndex = currentStepIndex + 1;
+      setCurrentStepIndex(nextIndex);
+      setStep(typeToStep(additionalFields[nextIndex].fieldType));
+    } else {
+      setStep('done');
     }
+  };
 
-    // -------------------- IMAGE 화면 --------------------
+  const handleSubmit = () => {
+    console.log('최종 제출 데이터:', {
+      jobPostId,
+      roadAddress,
+      answers,
+      finalCertFileName,
+    });
+    setSubmitted(true);
+    setStep('done');
+  };
+
+  // -------------------- DONE 화면 --------------------
+  if (step === 'done') {
     return (
-        <Topbar>
-            <div className="p-[13px]">
-                <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
-                    신청서 작성
-                </h2>
-                <h3 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
-                    증빙자료 사진 첨부가 필요합니다
-                </h3>
+      <Topbar>
+        <div className="p-[13px]">
+          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+            신청서 작성
+          </h2>
+          <h2 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+            {submitted
+              ? '신청 완료되었습니다'
+              : '신청 완료 전 마지막으로 신청서를 확인하세요'}
+          </h2>
 
-                <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
-                    {currentField?.fieldName}
+          <div className="mt-[40px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+            <p>{roadAddress}</p>
+          </div>
+          <div className="p-[18px] border-[1.3px] border-[#08D485] rounded-[13px] mt-[23px]">
+            <span className="text-[16px] text-[#414141]">기본 정보</span>
+            <div className="mt-[14px] text-[14px] text-[#414141]">
+              {formFields.map((field) => (
+                <div className="flex justify-between mb-[8px]" key={field.id}>
+                  <span className="font-semibold">{field.fieldName}</span>
+                  <span>{field.answer ?? '-'}</span>
                 </div>
-
-                <input
-                    type="file"
-                    className="mt-[16px] p-4 w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000] flex items-center justify-center"
-                    onChange={handleImageAnswerChange}
-                />
-                {currentField && answers[currentField.id] && (
-                    <p className="mt-2 text-[14px]">{answers[currentField.id]}</p>
-                )}
-
-                <div className="flex justify-between gap-[13px] mt-[255px]">
-                    <button
-                        onClick={goPrev}
-                        disabled={isFirst}
-                        className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
-                    >
-                        이전
-                    </button>
-                    <button
-                        onClick={goNext}
-                        className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
-                    >
-                        {isLast ? '다음' : '다음'}
-                    </button>
-                </div>
+              ))}
             </div>
-        </Topbar>
+          </div>
+
+          {additionalFields.map((field) => (
+            <div key={field.id} className="mt-[24px]">
+              <div className="w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+                {field.fieldName}
+              </div>
+              <div className="w-full border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] mt-[21px]">
+                {field.fieldType === 'TEXT' ? (
+                  <p className="text-[14px] whitespace-pre-wrap">
+                    {answers[field.id] ?? (
+                      <span className="text-gray-400">미작성</span>
+                    )}
+                  </p>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <p className="text-[14px]">{answers[field.id]}</p>
+                    {!submitted && (
+                      <input
+                        type="file"
+                        onChange={handleImageAnswerChange}
+                        className="ml-auto"
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+
+          <div className="mt-[39px]">
+            <label className="block mb-1 text-[14px] text-[#747474]">
+              {currentField?.fieldName || '자격증 이미지'}
+            </label>
+            <input
+              type="file"
+              onChange={handleFinalCertChange}
+              disabled={submitted}
+            />
+            {finalCertFileName && <p className="mt-2">{finalCertFileName}</p>}
+          </div>
+
+          {submitted ? (
+            <button
+              onClick={() => navigate('/')}
+              className="w-full h-[45px] mt-[24px] text-[16px] bg-[#08D485] text-black rounded-[8px]"
+            >
+              홈으로
+            </button>
+          ) : (
+            <div className="flex justify-between gap-[13px] mt-[24px]">
+              <button
+                onClick={() => {
+                  if (additionalFields.length > 0) {
+                    setCurrentStepIndex(additionalFields.length - 1);
+                    setStep(
+                      typeToStep(
+                        additionalFields[additionalFields.length - 1].fieldType
+                      )
+                    );
+                  }
+                }}
+                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]"
+              >
+                임시 저장
+              </button>
+              <button
+                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                onClick={handleSubmit}
+              >
+                제출
+              </button>
+            </div>
+          )}
+        </div>
+      </Topbar>
     );
+  }
+
+  // -------------------- TEXT 화면 --------------------
+  if (step === 'text') {
+    return (
+      <Topbar>
+        <div className="p-[13px]">
+          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+            신청서 작성
+          </h2>
+
+          <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+            {currentField?.fieldName}
+          </div>
+
+          <input
+            type="text"
+            className="mt-[16px] border p-2 w-full"
+            value={currentField ? answers[currentField.id] || '' : ''}
+            onChange={(e) => handleTextChange(e.target.value)}
+            placeholder="내용을 입력하세요"
+          />
+
+          <div className="flex justify-between gap-[13px] mt-[32px]">
+            <button
+              onClick={goPrev}
+              disabled={isFirst}
+              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+            >
+              이전
+            </button>
+            <button
+              onClick={goNext}
+              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+            >
+              {isLast ? '다음' : '다음'}
+            </button>
+          </div>
+        </div>
+      </Topbar>
+    );
+  }
+
+  // -------------------- IMAGE 화면 --------------------
+  return (
+    <Topbar>
+      <div className="p-[13px]">
+        <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+          신청서 작성
+        </h2>
+        <h3 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+          증빙자료 사진 첨부가 필요합니다
+        </h3>
+
+        <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+          {currentField?.fieldName}
+        </div>
+
+        <input
+          type="file"
+          className="mt-[16px] p-4 w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000] flex items-center justify-center"
+          onChange={handleImageAnswerChange}
+        />
+        {currentField && answers[currentField.id] && (
+          <p className="mt-2 text-[14px]">{answers[currentField.id]}</p>
+        )}
+
+        <div className="flex justify-between gap-[13px] mt-[255px]">
+          <button
+            onClick={goPrev}
+            disabled={isFirst}
+            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+          >
+            이전
+          </button>
+          <button
+            onClick={goNext}
+            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+          >
+            {isLast ? '다음' : '다음'}
+          </button>
+        </div>
+      </div>
+    </Topbar>
+  );
 };
 
 export default JobApplyExtendedForm;

--- a/src/pages/Personal/JobApplyExtendedForm.tsx
+++ b/src/pages/Personal/JobApplyExtendedForm.tsx
@@ -1,5 +1,10 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Topbar from '../../shared/components/topbar/Topbar';
 import { FormField } from './types/jobs';
+
+// Step 상태 타입
+type Step = 'text' | 'image' | 'done';
 
 type Props = {
   formFields: FormField[];
@@ -7,21 +12,224 @@ type Props = {
   jobPostId: number;
 };
 
-const JobApplyExtendedForm = ({ formFields }: Props) => {
+const JobApplyExtendedForm = ({ formFields, roadAddress, jobPostId }: Props) => {
+  const navigate = useNavigate();
+  const additionalFields = useMemo(() => formFields.slice(4), [formFields]);
+
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [finalCertFileName, setFinalCertFileName] = useState('');
+
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [submitted, setSubmitted] = useState(false);
+
+  const typeToStep = (t: FormField['fieldType']): Exclude<Step, 'done'> =>
+    t === 'IMAGE' ? 'image' : 'text';
+
+  const initialStep: Step =
+    additionalFields.length === 0 ? 'done' : typeToStep(additionalFields[0].fieldType);
+
+  const [step, setStep] = useState<Step>(initialStep);
+
+  const currentField = additionalFields[currentStepIndex];
+  const isFirst = currentStepIndex === 0;
+  const isLast = currentStepIndex === additionalFields.length - 1;
+
+  const handleTextChange = (value: string) => {
+    if (!currentField) return;
+    setAnswers((prev) => ({ ...prev, [currentField.id]: value }));
+  };
+
+  const handleImageAnswerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!currentField) return;
+    const file = e.target.files?.[0];
+    if (file) {
+      setAnswers((prev) => ({ ...prev, [currentField.id]: file.name }));
+    }
+  };
+
+  const handleFinalCertChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setFinalCertFileName(file.name);
+  };
+
+  const goPrev = () => {
+    if (isFirst) return;
+    const prevIndex = currentStepIndex - 1;
+    setCurrentStepIndex(prevIndex);
+    setStep(typeToStep(additionalFields[prevIndex].fieldType));
+  };
+
+  const goNext = () => {
+    if (!isLast) {
+      const nextIndex = currentStepIndex + 1;
+      setCurrentStepIndex(nextIndex);
+      setStep(typeToStep(additionalFields[nextIndex].fieldType));
+    } else {
+      setStep('done');
+    }
+  };
+
+  const handleSubmit = () => {
+    console.log('최종 제출 데이터:', {
+      jobPostId,
+      roadAddress,
+      answers,
+      finalCertFileName,
+    });
+    setSubmitted(true);
+    setStep('done');
+  };
+
+  // -------------------- DONE 화면 --------------------
+  if (step === 'done') {
+    return (
+      <Topbar>
+        <div className="p-[13px]">
+          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+            신청서 작성
+          </h2>
+          <h2 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+            {submitted ? '신청 완료되었습니다' : '신청 완료 전 마지막으로 신청서를 확인하세요'}
+          </h2>
+
+          <div className="mt-[40px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+            <p>{roadAddress}</p>
+          </div>
+
+          <div className="border p-4 mt-[24px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] ">
+            {additionalFields.map((field) => (
+              <div key={field.id} className="mb-3">
+                <p className="font-medium">{field.fieldName}</p>
+                <p className="text-[14px] break-words">
+                  {answers[field.id] ?? <span className="text-gray-400">미작성</span>}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-[39px]">
+            <label className="block mb-1 text-[14px] text-[#747474]">사회복지 자격증 이미지</label>
+            <input
+              type="file"
+              onChange={handleFinalCertChange}  
+              disabled={submitted}
+            />
+            {finalCertFileName && <p className="mt-2">{finalCertFileName}</p>}
+          </div>
+
+          {submitted ? (
+            <button
+              onClick={() => navigate('/')}
+              className="w-full h-[45px] mt-[24px] text-[16px] bg-[#08D485] text-black rounded-[8px]"
+            >
+              홈으로
+            </button>
+          ) : (
+            <div className="flex justify-between gap-[13px] mt-[24px]">
+              <button
+                onClick={() => {
+                  if (additionalFields.length > 0) {
+                    setCurrentStepIndex(additionalFields.length - 1);
+                    setStep(typeToStep(additionalFields[additionalFields.length - 1].fieldType));
+                  }
+                }}
+                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000]"
+              >
+                임시 저장
+              </button>
+              <button
+                className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+                onClick={handleSubmit}
+              >
+                제출
+              </button>
+            </div>
+          )}
+        </div>
+      </Topbar>
+    );
+  }
+
+  // -------------------- TEXT 화면 --------------------
+  if (step === 'text') {
+    return (
+      <Topbar>
+        <div className="p-[13px]">
+          <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+            신청서 작성
+          </h2>
+
+          <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+            {currentField?.fieldName}
+          </div>
+
+          <input
+            type="text"
+            className="mt-[16px] border p-2 w-full"
+            value={currentField ? answers[currentField.id] || '' : ''}
+            onChange={(e) => handleTextChange(e.target.value)}
+            placeholder="내용을 입력하세요"
+          />
+
+          <div className="flex justify-between gap-[13px] mt-[32px]">
+            <button
+              onClick={goPrev}
+              disabled={isFirst}
+              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+            >
+              이전
+            </button>
+            <button
+              onClick={goNext}
+              className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+            >
+              {isLast ? '다음' : '다음'}
+            </button>
+          </div>
+        </div>
+      </Topbar>
+    );
+  }
+
+  // -------------------- IMAGE 화면 --------------------
   return (
     <Topbar>
-      <div>
-        <h2>추가 질문 포함 신청서</h2>
-        {formFields.map((field) => (
-          <div key={field.id}>
-            <label>{field.fieldName}</label>
-            {field.fieldType === 'TEXT' && (
-              <input type="text" className="border p-1" />
-            )}
-            {field.fieldType === 'IMAGE' && <input type="file" />}
-            {/* CHOICE 타입 등은 나중에 확장 가능 */}
-          </div>
-        ))}
+      <div className="p-[13px]">
+        <h2 className="text-[20px] text-[#747474] font-semibold mt-[8px] text-center">
+          신청서 작성
+        </h2>
+        <h3 className="text-[16px] text-[#747474] font-semibold mt-[8px]">
+          증빙자료 사진 첨부가 필요합니다
+        </h3>
+
+        <div className="mt-[24px] w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-white text-[#000000] flex items-center justify-center">
+          {currentField?.fieldName}
+        </div>
+
+        <input
+          type="file"
+          className="mt-[16px] p-4 w-full h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000] flex items-center justify-center"
+          onChange={handleImageAnswerChange}
+        />
+        {currentField && answers[currentField.id] && (
+          <p className="mt-2 text-[14px]">{answers[currentField.id]}</p>
+        )}
+
+        <div className="flex justify-between gap-[13px] mt-[255px]">
+          <button
+            onClick={goPrev}
+            disabled={isFirst}
+            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] text-[#000000] disabled:opacity-40"
+          >
+            이전
+          </button>
+          <button
+            onClick={goNext}
+            className="w-1/2 h-[45px] text-[16px] border-[1.3px] border-[#08D485] rounded-[8px] bg-[#08D485] text-[#000000]"
+          >
+            {isLast ? '다음' : '다음'}
+          </button>
+        </div>
       </div>
     </Topbar>
   );

--- a/src/pages/Personal/JobDetailPage.tsx
+++ b/src/pages/Personal/JobDetailPage.tsx
@@ -1,11 +1,13 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import { toast } from 'react-toastify';
 import Topbar from '../../shared/components/topbar/Topbar';
 import { useJobDetail } from './hooks/useDetail';
 import { useSaveToggle } from './hooks/useSaveToggle';
 import { useShow } from './hooks/useShow';
 import { useApplication } from './hooks/useApplication';
+
 
 const JobDetailPage = () => {
   const { jobId } = useParams();
@@ -15,26 +17,45 @@ const JobDetailPage = () => {
   const { data: job, isLoading, isError } = useJobDetail(jobPostId);
   const { mutate: saveJob, isPending } = useSaveToggle(jobPostId);
   const { data: savedJobs } = useShow();
+  const queryClient = useQueryClient();
+
+  const { useEnsureApplication, useGetMyApplications } = useApplication();
+  const { mutate: ensureApplication, isPending: isApplying } = useEnsureApplication();
+  const { data: myApplications } = useGetMyApplications();
+
   const isSaved = savedJobs?.some(
     (bookmark) => bookmark.jobPostDetailDTO.images[0]?.jobPostId === jobPostId
   );
-  const queryClient = useQueryClient();
+
+  const isAlreadyApplied = myApplications?.some(
+    (app) => app.jobPostId === jobPostId && app.applicationStatus === 'SUBMITTED'
+  );
+
   const handleSave = () => {
     if (!isSaved) {
       saveJob();
     }
   };
-  const { useEnsureApplication } = useApplication();
-  const { mutate: ensureApplication, isPending: isApplying } =
-    useEnsureApplication();
 
   const handleApply = () => {
+    if (isAlreadyApplied) {
+      toast.info('이미 신청한 공고입니다.');
+      return;
+    }
+
     ensureApplication(jobPostId, {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['applications', 'mine'] });
         navigate('/personal/jobs/drafts');
       },
-      onError: () => {
+      onError: (error) => {
+        if (axios.isAxiosError(error)) {
+          const msg = error.response?.data?.message;
+          if (msg?.includes('이미 신청')) {
+            toast.info('이미 신청한 공고입니다.');
+            return;
+          }
+        }
         toast.error('신청에 실패했습니다.');
       },
     });
@@ -55,6 +76,7 @@ const JobDetailPage = () => {
       </Topbar>
     );
   }
+
   return (
     <div>
       <div className="w-full h-full">
@@ -103,11 +125,17 @@ const JobDetailPage = () => {
           {/* 하단 버튼 */}
           <div className="w-[301px] flex gap-[13px] mt-[36px]">
             <button
-              onClick={handleApply}
-              disabled={isApplying}
-              className="w-[144px] h-[45px] border-[1.3px] border-[var(--main-green)] rounded-[8px] bg-white text-[16px] font-medium text-black"
+              onClick={isAlreadyApplied ? undefined : handleApply}
+              disabled={isAlreadyApplied || isApplying}
+              className={`w-[144px] h-[45px] border-[1.3px] border-[var(--main-green)] rounded-[8px] text-[16px] font-medium text-black ${
+                isAlreadyApplied ? 'bg-[#ccc]' : 'bg-white'
+              }`}
             >
-              {isApplying ? '신청 중...' : '신청'}
+              {isAlreadyApplied
+                ? '신청함'
+                : isApplying
+                ? '신청 중...'
+                : '신청'}
             </button>
             <button
               onClick={handleSave}

--- a/src/pages/Personal/JobDetailPage.tsx
+++ b/src/pages/Personal/JobDetailPage.tsx
@@ -8,7 +8,6 @@ import { useSaveToggle } from './hooks/useSaveToggle';
 import { useShow } from './hooks/useShow';
 import { useApplication } from './hooks/useApplication';
 
-
 const JobDetailPage = () => {
   const { jobId } = useParams();
   const navigate = useNavigate();
@@ -20,7 +19,8 @@ const JobDetailPage = () => {
   const queryClient = useQueryClient();
 
   const { useEnsureApplication, useGetMyApplications } = useApplication();
-  const { mutate: ensureApplication, isPending: isApplying } = useEnsureApplication();
+  const { mutate: ensureApplication, isPending: isApplying } =
+    useEnsureApplication();
   const { data: myApplications } = useGetMyApplications();
 
   const isSaved = savedJobs?.some(
@@ -28,7 +28,8 @@ const JobDetailPage = () => {
   );
 
   const isAlreadyApplied = myApplications?.some(
-    (app) => app.jobPostId === jobPostId && app.applicationStatus === 'SUBMITTED'
+    (app) =>
+      app.jobPostId === jobPostId && app.applicationStatus === 'SUBMITTED'
   );
 
   const handleSave = () => {
@@ -131,11 +132,7 @@ const JobDetailPage = () => {
                 isAlreadyApplied ? 'bg-[#ccc]' : 'bg-white'
               }`}
             >
-              {isAlreadyApplied
-                ? '신청함'
-                : isApplying
-                ? '신청 중...'
-                : '신청'}
+              {isAlreadyApplied ? '신청함' : isApplying ? '신청 중...' : '신청'}
             </button>
             <button
               onClick={handleSave}

--- a/src/pages/Personal/home/HomeAfterLogin.tsx
+++ b/src/pages/Personal/home/HomeAfterLogin.tsx
@@ -82,7 +82,7 @@ const HomeAfterLogin = () => {
             {data?.jobPostList.slice(0, 5).map((job) => (
               <div
                 key={job.id}
-                onClick={() => navigate(`/personal/jobs/recommend/${job.id}`)} 
+                onClick={() => navigate(`/personal/jobs/recommend/${job.id}`)}
                 className="cursor-pointer w-[298px] h-[196px] mb-[17px] flex flex-col items-center justify-center gap-[12px] rounded-[13px] border-[1px] border-[#D3D3D3]"
               >
                 <span className="text-center mt-[17px]">{job.description}</span>

--- a/src/pages/Personal/home/HomeAfterLogin.tsx
+++ b/src/pages/Personal/home/HomeAfterLogin.tsx
@@ -82,16 +82,16 @@ const HomeAfterLogin = () => {
             {data?.jobPostList.slice(0, 5).map((job) => (
               <div
                 key={job.id}
-                onClick={() => navigate(`/jobs/${job.id}`)} // ❗️[임의] 상세페이지 경로 확인 필요
+                onClick={() => navigate(`/personal/jobs/recommend/${job.id}`)} 
                 className="cursor-pointer w-[298px] h-[196px] mb-[17px] flex flex-col items-center justify-center gap-[12px] rounded-[13px] border-[1px] border-[#D3D3D3]"
               >
-                <span className="text-center px-2">{job.title}</span>
+                <span className="text-center mt-[17px]">{job.description}</span>
                 <img
                   className="w-[250px] h-[120px] object-cover rounded-[8px] border-[1px] border-[#A4A4A4]"
                   src={job.images?.[0]?.imageUrl ?? ''}
                   alt={job.title}
                 />
-                <span className="text-[14px] text-[#5f5f5f]">
+                <span className="text-[14px] text-[#5f5f5f] mb-[10px]">
                   {job.address}
                 </span>
               </div>

--- a/src/pages/Personal/types/jobapplication.ts
+++ b/src/pages/Personal/types/jobapplication.ts
@@ -18,6 +18,11 @@ export type FieldAndAnswer = TextAnswer | ImageAnswer;
 
 export type PostApplicationDirectRequest = {
   jobPostId: number;
-  applicationStatus: 'NON_STARTED' | 'SUBMITTED';
+  applicationStatus:  
+    | 'NON_STARTED'
+    | 'DRAFT'
+    | 'SUBMITTED'
+    | 'APPROVED'
+    | 'REJECTED';
   fieldAndAnswer: FieldAndAnswer[];
 };

--- a/src/pages/Personal/types/jobapplication.ts
+++ b/src/pages/Personal/types/jobapplication.ts
@@ -18,7 +18,7 @@ export type FieldAndAnswer = TextAnswer | ImageAnswer;
 
 export type PostApplicationDirectRequest = {
   jobPostId: number;
-  applicationStatus:  
+  applicationStatus:
     | 'NON_STARTED'
     | 'DRAFT'
     | 'SUBMITTED'


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #172 

## 📝 작업 내용

- 개인 신청 폼 작성 ui 구현
- 파일 설명
- jobapplypagetest => JobApplyDefaultForm(추가 질문이 없을때 폼), JobApplyExtendedForm(추가 질문이 있을때 폼) 분기 페이지 파일
- jobapplication 타입 정의 파일
- jobapplicationapi api함수 정의 파일
- 훅은 동작에 따라 생성 후 ui에 연결.

- 현재까지 구현된 로직 => 추가질문이 있는 공고와 없는 공고응 분리해서 각각의 페이지로 이동하여 추가 질문이 없을 경우 공고 신청 api연결 완료
- 추가 질문이 있는 경우 해당 추가 질문에 폼으로 나오도록 설정 완료. 이때 폼이 image일 경우 ui구현이 완료됐지만 text일 경우 ai 입력에 맞는 추가 ui 구현 필요.

<br />
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 🖼️ 구현 화면

<br />
<!-- 애니메이션이 있다면 gif나 영상 첨부 해주세요  -->

## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
