### PR TITLE
[feat] 개인(시니어/보호자) 플로우 체크

### DIFF
--- a/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationDetail.tsx
+++ b/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { MdOutlineFileDownload } from 'react-icons/md';
-import { toast } from 'react-toastify';
+import ImageField from '../../../../../shared/components/field/ImageField';
+import TextField from '../../../../../shared/components/field/TextField';
 import Topbar from '../../../../../shared/components/topbar/Topbar';
 import { getSeniorData } from '../../../apis/my/seniorMy';
 import Loading from '../../../../../shared/components/Loading';
@@ -11,7 +11,12 @@ import {
   questionAndAnswer,
   LinkedSenior,
 } from '../../../types/userInfo';
-import axiosInstance from '../../../../../shared/apis/axiosInstance';
+import { formatPhone } from '../../../../../shared/utils/userInfoUtils';
+
+const Gender = {
+  FEMALE: '여성',
+  MALE: '남성',
+} as const;
 
 const CareCheckApplicationDetail = () => {
   const { seniorId, applicationId } = useParams();
@@ -29,10 +34,10 @@ const CareCheckApplicationDetail = () => {
       value:
         applicationData?.roadAddress + ' ' + applicationData?.detailAddress,
     },
-    { label: '시급', value: applicationData?.hourlyWage },
+    { label: '시급', value: applicationData?.hourlyWage, unit: '원' },
     { label: '근무시간', value: applicationData?.workingTime },
-    { label: '월급', value: applicationData?.monthlySalary },
-    { label: '연봉', value: applicationData?.yearSalary },
+    { label: '월급', value: applicationData?.monthlySalary, unit: '원' },
+    { label: '연봉', value: applicationData?.yearSalary, unit: '원' },
   ];
 
   // 시니어 데이터 조회
@@ -63,10 +68,6 @@ const CareCheckApplicationDetail = () => {
       .catch((err) => console.error('지원서 상세 조회 에러: ', err))
       .finally(() => setLoading(false));
   }, [seniorId, applicationId]);
-
-  // useEffect(() => {
-  //   console.log(applicationData);
-  // }, [applicationData]);
 
   return (
     <div className="flex flex-col">
@@ -113,19 +114,26 @@ const CareCheckApplicationDetail = () => {
                 </div>
                 <div className="flex justify-between">
                   <span>성별</span>
-                  <span>{seniorData?.gender}</span>
+                  <span>
+                    {seniorData?.gender ? Gender[seniorData.gender] : ''}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span>나이</span>
-                  <span>{'75'}세</span>
+                  <span>{seniorData?.age}세</span>
                 </div>
                 <div className="flex justify-between">
                   <span>전화번호</span>
-                  <span>{seniorData?.seniorPhone}</span>
+                  <span>
+                    {seniorData?.seniorPhone &&
+                      formatPhone(seniorData?.seniorPhone)}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span>거주지</span>
-                  <span>{seniorData?.roadAddress}</span>
+                  <span>
+                    {seniorData?.roadAddress + ' ' + seniorData?.detailAddress}
+                  </span>
                 </div>
               </div>
             </div>
@@ -160,56 +168,3 @@ const CareCheckApplicationDetail = () => {
 };
 
 export default CareCheckApplicationDetail;
-
-interface ImageFieldProps {
-  fieldName: string;
-  answerContent: ImageObject;
-}
-
-interface TextFieldProps {
-  fieldName: string;
-  answerContent: string;
-}
-
-const ImageField = ({ fieldName, answerContent }: ImageFieldProps) => {
-  const handleViewFile = async (keyName: string) => {
-    try {
-      const res = await axiosInstance.get(
-        `/api/s3/presigned/download/${keyName}`
-      );
-      window.open(res.data.result.url, '_blank');
-    } catch (err) {
-      console.error('첨부파일 다운로드 실패', err);
-      toast.error('파일을 불러올 수 없습니다.');
-    }
-  };
-
-  return (
-    <div className="flex flex-col text-[14px] font-[Pretendard JP] font-[400]">
-      <div className="flex items-center gap-[4px] mb-[4px]">
-        <span className="text-[#747474]">{fieldName}</span>
-        <span className="text-[#FF0004]">(필수)</span>
-      </div>
-      <div className="flex justify-center gap-[11px]">
-        <div className="flex jusitfy-between items-center w-[297px] h-[45px] p-[12px] rounded-[8px] border-[1.3px] border-[#08D485]">
-          <span className="truncate">{answerContent.originalFileName}</span>
-          <MdOutlineFileDownload
-            size={32}
-            onClick={() => handleViewFile(answerContent.keyName)}
-          />
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const TextField = ({ fieldName, answerContent }: TextFieldProps) => {
-  return (
-    <div className="flex flex-col justify-around w-[297px] h-[134px] rounded-[13px] px-[16px] py-[10px] border-[1.3px] border-[#08D485]">
-      <span className="text-[16px] font-[600] pb-[12px]">{fieldName}</span>
-      <div className="flex justify-between">
-        <span>{answerContent}</span>
-      </div>
-    </div>
-  );
-};

--- a/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationDetail.tsx
+++ b/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationDetail.tsx
@@ -11,7 +11,10 @@ import {
   questionAndAnswer,
   LinkedSenior,
 } from '../../../types/userInfo';
-import { formatPhone } from '../../../../../shared/utils/userInfoUtils';
+import {
+  formatMoney,
+  formatPhone,
+} from '../../../../../shared/utils/userInfoUtils';
 
 const Gender = {
   FEMALE: '여성',
@@ -34,10 +37,26 @@ const CareCheckApplicationDetail = () => {
       value:
         applicationData?.roadAddress + ' ' + applicationData?.detailAddress,
     },
-    { label: '시급', value: applicationData?.hourlyWage, unit: '원' },
+    {
+      label: '시급',
+      value:
+        applicationData?.hourlyWage && formatMoney(applicationData?.hourlyWage),
+      unit: '원',
+    },
     { label: '근무시간', value: applicationData?.workingTime },
-    { label: '월급', value: applicationData?.monthlySalary, unit: '원' },
-    { label: '연봉', value: applicationData?.yearSalary, unit: '원' },
+    {
+      label: '월급',
+      value:
+        applicationData?.monthlySalary &&
+        formatMoney(applicationData?.monthlySalary),
+      unit: '원',
+    },
+    {
+      label: '연봉',
+      value:
+        applicationData?.yearSalary && formatMoney(applicationData?.yearSalary),
+      unit: '원',
+    },
   ];
 
   // 시니어 데이터 조회

--- a/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationResults.tsx
+++ b/src/pages/Personal/my/cares/care-seniors/CareCheckApplicationResults.tsx
@@ -118,11 +118,17 @@ const CareCheckApplicationResults = () => {
                         </span>
                       </div>
                       <div className="w-[292px] h-[165px] rounded-[10px] border-[1.3px] border-[#A4A4A4] overflow-hidden">
-                        <img
-                          className="w-[292px] h-[165px]"
-                          src={apply.images[0].imageUrl}
-                          alt="기업 대표 이미지"
-                        />
+                        {apply.images.length > 0 ? (
+                          <img
+                            className="w-[292px] h-[165px]"
+                            src={apply.images[0].imageUrl}
+                            alt="기업 대표 이미지"
+                          />
+                        ) : (
+                          <div className="text-[13px] text-gray-600">
+                            첨부된 파일이 없습니다.
+                          </div>
+                        )}
                       </div>
                       <div className="flex justify-center items-center gap-[6px] pt-[16px] pb-[6px]">
                         <button

--- a/src/pages/Personal/my/cares/care-seniors/SeniorExtraInfo.tsx
+++ b/src/pages/Personal/my/cares/care-seniors/SeniorExtraInfo.tsx
@@ -24,7 +24,7 @@ const SeniorExtraInfo = () => {
         );
         setSeniorData(value);
       })
-      .catch((err) => console.error('시니어 데이터 조회 에러: ', err))
+      .catch((err) => console.error('시니어 기본 정보 조회 실패: ', err))
       .finally(() => setLoading(false));
   }, [seniorIdNum]);
 
@@ -34,7 +34,7 @@ const SeniorExtraInfo = () => {
     getSeniorData(`/api/seniors/${seniorIdNum}/questions`)
       .then((data) => setQuestionList(data.result))
       .catch((err) =>
-        console.error('시니어 추가질문 답변 리스트 조회 에러: ', err)
+        console.error('시니어 추가질문 답변 리스트 조회 실패: ', err)
       )
       .finally(() => setLoading(false));
   }, [seniorIdNum]);

--- a/src/pages/Personal/my/cares/care-seniors/SeniorExtraInfoEdit.tsx
+++ b/src/pages/Personal/my/cares/care-seniors/SeniorExtraInfoEdit.tsx
@@ -73,13 +73,9 @@ const SeniorExtraInfoEdit = () => {
         return;
       }
 
-      const res = await axiosInstance.put(
-        `/api/seniors/${seniorData?.seniorId}/answers`,
-        {
-          answers: patchArr,
-        }
-      );
-      console.log(res.data);
+      await axiosInstance.put(`/api/seniors/${seniorData?.seniorId}/answers`, {
+        answers: patchArr,
+      });
     } catch (err) {
       console.error('추가 질문 수정 에러: ', err);
     } finally {

--- a/src/pages/Personal/my/seniors/SeniorApplyDetail.tsx
+++ b/src/pages/Personal/my/seniors/SeniorApplyDetail.tsx
@@ -12,6 +12,11 @@ import TextField from '../../../../shared/components/field/TextField';
 import { questionAndAnswer } from '../../types/userInfo';
 import Loading from '../../../../shared/components/Loading';
 
+const Gender = {
+  FEMALE: '여성',
+  MALE: '남성',
+} as const;
+
 const SeniorApplyDetail = () => {
   const [seniorData, setSeniorData] = useState<Info | null>(null);
   const { applicationId } = useParams();
@@ -125,10 +130,12 @@ const SeniorApplyDetail = () => {
                   <div className="w-[80px]">성함</div>
                   <div className="w-[180px]">{seniorData?.name}</div>
                 </div>
-                {/* <div className="flex gap-[5px]">
-                <div className="w-[80px]">성별</div>
-                <div className="w-[180px]">{seniorData?.gender}</div>
-              </div> */}
+                <div className="flex gap-[5px]">
+                  <div className="w-[80px]">성별</div>
+                  <div className="w-[180px]">
+                    {seniorData?.gender ? Gender[seniorData.gender] : ''}
+                  </div>
+                </div>
                 <div className="flex gap-[5px]">
                   <div className="w-[80px]">나이</div>
                   <div className="w-[180px]">{seniorData?.age}세</div>

--- a/src/pages/Personal/my/seniors/SeniorApplyDetail.tsx
+++ b/src/pages/Personal/my/seniors/SeniorApplyDetail.tsx
@@ -3,11 +3,14 @@ import { useParams } from 'react-router-dom';
 import Topbar from '../../../../shared/components/topbar/Topbar';
 import { getSeniorData } from '../../apis/my/seniorMy';
 import { ApplicationDetail, ImageObject, Info } from '../../types/userInfo';
-import { formatPhone } from '../../../../shared/utils/userInfoUtils';
-import axiosInstance from '../../../../shared/apis/axiosInstance';
+import {
+  formatMoney,
+  formatPhone,
+} from '../../../../shared/utils/userInfoUtils';
 import ImageField from '../../../../shared/components/field/ImageField';
 import TextField from '../../../../shared/components/field/TextField';
 import { questionAndAnswer } from '../../types/userInfo';
+import Loading from '../../../../shared/components/Loading';
 
 const SeniorApplyDetail = () => {
   const [seniorData, setSeniorData] = useState<Info | null>(null);
@@ -28,18 +31,16 @@ const SeniorApplyDetail = () => {
 
   // 시니어 지원서 상세조회
   useEffect(() => {
+    setLoading(true);
     getSeniorData(`/api/applications/me/details/${applicationId}`)
       .then((data) => {
         const res = data.result;
         setApplicationDetail(res as ApplicationDetail);
         setAnswerData(res.questionAndAnswerList);
       })
-      .catch((err) => console.error('지원정보 조회 에러', err));
+      .catch((err) => console.error('지원정보 조회 에러', err))
+      .finally(() => setLoading(false));
   }, [applicationId]);
-
-  useEffect(() => {
-    console.log(applicationDetail);
-  }, [applicationDetail]);
 
   const viewData = [
     {
@@ -53,7 +54,9 @@ const SeniorApplyDetail = () => {
     },
     {
       label: '시급',
-      value: applicationDetail?.hourlyWage,
+      value:
+        applicationDetail?.hourlyWage &&
+        formatMoney(applicationDetail?.hourlyWage),
       unit: '원',
     },
     {
@@ -62,34 +65,19 @@ const SeniorApplyDetail = () => {
     },
     {
       label: '월급',
-      value: applicationDetail?.monthlySalary,
+      value:
+        applicationDetail?.monthlySalary &&
+        formatMoney(applicationDetail?.monthlySalary),
       unit: '원',
     },
     {
       label: '연봉',
-      value: applicationDetail?.yearSalary,
+      value:
+        applicationDetail?.yearSalary &&
+        formatMoney(applicationDetail?.yearSalary),
       unit: '원',
     },
   ];
-
-  // 첨부 파일 조회
-  const handleFileView = async (keyName: string) => {
-    try {
-      const res = await axiosInstance.get('/api/s3/presigned/download', {
-        params: keyName,
-      });
-      const presignedUrl = res.data?.result?.url;
-
-      if (presignedUrl) {
-        window.open(presignedUrl, '_blank'); //새 탭에서 열기
-      } else {
-        alert('파일 url을 가져오지 못했습니다');
-      }
-    } catch (err) {
-      console.error('파일 열기 실패: ', err);
-      alert('파일을 불러오는 중 오류가 발생했습니다.');
-    }
-  };
 
   return (
     <div className="flex flex-col">
@@ -97,89 +85,93 @@ const SeniorApplyDetail = () => {
         <div className="relative text-center font-[pretendard JP] font-[600] text-[20px] text-[#747474] py-[10px] border-b-[1.3px] border-[#CCCCCC]">
           신청 결과
         </div>
-        <div className="h-[572px] overflow-y-scroll scrollbar-hide flex flex-col justify-start items-center gap-[16px] py-[20px] text-[14px] font-[500] text-[Pretendard] text-[#414141]">
-          <div className="w-[292px] h-[165px] rounded-[10px] border-[1.3px] border-[#A4A4A4]">
-            <img
-              className="w-[292px] h-[165px] rounded-[10px]"
-              src={applicationDetail?.images[0].imageUrl}
-              alt="기업 대표 사진"
-            />
-          </div>
-          <div className="flex flex-col justify-around w-[297px] h-[173px] px-[16px] py-[10px] rounded-[13px] border-[1.3px] border-[#08D485]">
-            <span className="text-[16px] font-[600] pb-[12px]">
-              {applicationDetail?.title}
-            </span>
-            <div className="leading-[1.8]">
-              {viewData.map((data, idx) => {
-                if (data.value) {
-                  return (
-                    <div key={idx} className="flex justify-between">
-                      <span>{data.label}</span>
-                      <div>
-                        <span>{data.value}</span>
-                        {data.unit && <span>{data.unit}</span>}
-                      </div>
-                    </div>
-                  );
-                }
-              })}
+        {loading ? (
+          <Loading />
+        ) : (
+          <div className="h-[572px] overflow-y-scroll scrollbar-hide flex flex-col justify-start items-center gap-[16px] py-[20px] text-[14px] font-[500] text-[Pretendard] text-[#414141]">
+            <div className="w-[292px] h-[165px] rounded-[10px] border-[1.3px] border-[#A4A4A4]">
+              <img
+                className="w-[292px] h-[165px] rounded-[10px]"
+                src={applicationDetail?.images[0].imageUrl}
+                alt="기업 대표 사진"
+              />
             </div>
-          </div>
-          <div className="flex flex-col justify-around w-[297px] h-auto px-[16px] py-[10px] rounded-[13px] border-[1.3px] border-[#08D485]">
-            <span className="text-[16px] font-[pretendard JP] font-[600] pb-[12px]">
-              기본 정보
-            </span>
-            <div className="leading-[1.8]">
-              <div className="flex gap-[5px]">
-                <div className="w-[80px]">성함</div>
-                <div className="w-[180px]">{seniorData?.name}</div>
+            <div className="flex flex-col justify-around w-[297px] h-[173px] px-[16px] py-[10px] rounded-[13px] border-[1.3px] border-[#08D485]">
+              <span className="text-[16px] font-[600] pb-[12px]">
+                {applicationDetail?.title}
+              </span>
+              <div className="leading-[1.8]">
+                {viewData.map((data, idx) => {
+                  if (data.value) {
+                    return (
+                      <div key={idx} className="flex justify-between">
+                        <span>{data.label}</span>
+                        <div>
+                          <span>{data.value}</span>
+                          {data.unit && <span>{data.unit}</span>}
+                        </div>
+                      </div>
+                    );
+                  }
+                })}
               </div>
-              {/* <div className="flex gap-[5px]">
+            </div>
+            <div className="flex flex-col justify-around w-[297px] h-auto px-[16px] py-[10px] rounded-[13px] border-[1.3px] border-[#08D485]">
+              <span className="text-[16px] font-[pretendard JP] font-[600] pb-[12px]">
+                기본 정보
+              </span>
+              <div className="leading-[1.8]">
+                <div className="flex gap-[5px]">
+                  <div className="w-[80px]">성함</div>
+                  <div className="w-[180px]">{seniorData?.name}</div>
+                </div>
+                {/* <div className="flex gap-[5px]">
                 <div className="w-[80px]">성별</div>
                 <div className="w-[180px]">{seniorData?.gender}</div>
               </div> */}
-              <div className="flex gap-[5px]">
-                <div className="w-[80px]">나이</div>
-                <div className="w-[180px]">{seniorData?.age}</div>
-              </div>
-              <div className="flex gap-[5px]">
-                <div className="w-[80px]">전화번호</div>
-                <div className="w-[180px]">
-                  {seniorData?.phone && formatPhone(seniorData?.phone)}
+                <div className="flex gap-[5px]">
+                  <div className="w-[80px]">나이</div>
+                  <div className="w-[180px]">{seniorData?.age}세</div>
                 </div>
-              </div>
-              <div className="flex gap-[5px]">
-                <div className="w-[80px]">거주지</div>
-                <div className="w-[180px]">
-                  {seniorData?.roadAddress + ' ' + seniorData?.detailAddress}
+                <div className="flex gap-[5px]">
+                  <div className="w-[80px]">전화번호</div>
+                  <div className="w-[180px]">
+                    {seniorData?.phone && formatPhone(seniorData?.phone)}
+                  </div>
+                </div>
+                <div className="flex gap-[5px]">
+                  <div className="w-[80px]">거주지</div>
+                  <div className="w-[180px]">
+                    {seniorData?.roadAddress + ' ' + seniorData?.detailAddress}
+                  </div>
                 </div>
               </div>
             </div>
+            {answerData?.length > 0 ? (
+              <>
+                {answerData?.map((answer, idx) => {
+                  if (answer.fieldType === 'IMAGE') {
+                    return (
+                      <ImageField
+                        key={idx}
+                        fieldName={answer.fieldName}
+                        answerContent={answer.answerContent as ImageObject}
+                      />
+                    );
+                  } else if (answer.fieldType === 'TEXT') {
+                    return (
+                      <TextField
+                        key={idx}
+                        fieldName={answer.fieldName}
+                        answerContent={answer.answerContent as string}
+                      />
+                    );
+                  }
+                })}
+              </>
+            ) : undefined}
           </div>
-          {answerData?.length > 0 ? (
-            <>
-              {answerData?.map((answer, idx) => {
-                if (answer.fieldType === 'IMAGE') {
-                  return (
-                    <ImageField
-                      key={idx}
-                      fieldName={answer.fieldName}
-                      answerContent={answer.answerContent as ImageObject}
-                    />
-                  );
-                } else if (answer.fieldType === 'TEXT') {
-                  return (
-                    <TextField
-                      key={idx}
-                      fieldName={answer.fieldName}
-                      answerContent={answer.answerContent as string}
-                    />
-                  );
-                }
-              })}
-            </>
-          ) : undefined}
-        </div>
+        )}
       </Topbar>
     </div>
   );

--- a/src/pages/Personal/my/seniors/SeniorApplyResults.tsx
+++ b/src/pages/Personal/my/seniors/SeniorApplyResults.tsx
@@ -114,14 +114,20 @@ const SeniorApplyResults = () => {
                       </span>
                     </div>
                     <div className="w-[292px] h-[165px] rounded-[10px] border-[1.3px] border-[#A4A4A4] overflow-hidden">
-                      <img
-                        className="w-[292px] h-[165px] object-cover"
-                        src={
-                          apply.images?.[0]?.imageUrl ||
-                          '/images/placeholder.png'
-                        }
-                        alt="기업 대표 이미지"
-                      />
+                      {apply.images.length > 0 ? (
+                        <img
+                          className="w-[292px] h-[165px] object-cover"
+                          src={
+                            apply.images?.[0]?.imageUrl ||
+                            '/images/placeholder.png'
+                          }
+                          alt="기업 대표 이미지"
+                        />
+                      ) : (
+                        <div className="text-[13px] text-gray-600">
+                          첨부된 파일이 없습니다.
+                        </div>
+                      )}
                     </div>
                     <div className="flex justify-center items-center gap-[6px] pt-[16px] pb-[6px]">
                       <button

--- a/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
+++ b/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import DaumPostcode from 'react-daum-postcode';
 import { Info } from '../../../types/userInfo';
@@ -11,15 +11,30 @@ import {
 } from '../../../../../shared/utils/userInfoUtils';
 import Loading from '../../../../../shared/components/Loading';
 
-type OutletContext = { setChanges: (changes: Partial<Info>) => void };
+// type OutletContext = { setChanges: (changes: Partial<Info>) => void };
 
 const BasicInfoEdit = () => {
   const navigate = useNavigate();
-  const { setChanges } = useOutletContext<OutletContext>();
+  const { setChanges, editedInfo, setEditedInfo, refs } = useOutletContext<{
+    setChanges: (changes: Partial<Info>) => void;
+    editedInfo: Info | null;
+    setEditedInfo: React.Dispatch<React.SetStateAction<Info | null>>;
+    refs: {
+      ageRef: React.RefObject<HTMLInputElement>;
+      phoneRef: React.RefObject<HTMLInputElement>;
+      jobRef: React.RefObject<HTMLSelectElement>;
+    };
+  }>();
   const [originalInfo, setOriginalInfo] = useState<Info | null>(null);
-  const [editedInfo, setEditedInfo] = useState<Info | null>(null);
+  // const [editedInfo, setEditedInfo] = useState<Info | null>(null);
   const [isPhoneEditing, setIsPhoneEditing] = useState<boolean>(false);
   const [isPostcodeOpen, setIsPostCodeOpen] = useState<boolean>(false);
+
+  // ref
+  const phoneRef = useRef<HTMLInputElement>(null);
+  const detailAddressRef = useRef<HTMLInputElement>(null);
+  const jobRef = useRef<HTMLSelectElement>(null);
+  const experiencePeriodRef = useRef<HTMLSelectElement>(null);
 
   const handleRoadAddress = (data: any) => {
     handleChange('roadAddress', data.roadAddress);
@@ -34,14 +49,14 @@ const BasicInfoEdit = () => {
         setEditedInfo(me);
       })
       .catch((err) => console.error('시니어 정보 조회 실패: ', err));
-  }, []);
+  }, [setEditedInfo]);
 
   // 뷰전용 데이터 로드
   const infoData = useMemo(() => {
     if (!editedInfo) return [];
     return [
       { label: '이름', value: editedInfo.name },
-      { label: 'id', value: editedInfo.username },
+      { label: '아이디', value: editedInfo.username },
       { label: '비밀번호', value: '' },
       { label: '나이', value: String(editedInfo.age) },
       { label: '연락처', value: formatPhone(editedInfo.phone) },
@@ -110,6 +125,7 @@ const BasicInfoEdit = () => {
                   </div>
                 ) : label === '연락처' ? (
                   <input
+                    ref={phoneRef}
                     className="w-[200px] h-[45px] px-[10px] py-[4px] text-center border-[1.3px] border-[#E1E1E1] rounded-[8px] focus:text-black focus:outline-black"
                     value={
                       isPhoneEditing
@@ -129,6 +145,7 @@ const BasicInfoEdit = () => {
                   />
                 ) : label === '상세주소' ? (
                   <input
+                    ref={detailAddressRef}
                     className="w-[200px] h-[45px] px-[10px] py-[4px] text-center border-[1.3px] border-[#E1E1E1] rounded-[8px] focus:text-black focus:outline-black"
                     value={editedInfo?.detailAddress ?? ''}
                     onChange={(e) =>
@@ -138,6 +155,7 @@ const BasicInfoEdit = () => {
                 ) : // 드롭다운메뉴 사용파트
                 label === '직무' ? (
                   <select
+                    ref={jobRef}
                     className="w-[200px] h-[45px] border-[1.3px] border-[#E1E1E1] rounded-[8px] pl-[10px] focus:text-black focus:outline-black"
                     value={editedInfo?.job ?? ''}
                     onChange={(e) =>
@@ -154,6 +172,7 @@ const BasicInfoEdit = () => {
                   </select>
                 ) : label === '기간' ? (
                   <select
+                    ref={experiencePeriodRef}
                     className="w-[200px] h-[45px] border-[1.3px] border-[#E1E1E1] rounded-[8px] pl-[10px] focus:text-black focus:outline-black"
                     value={editedInfo?.experiencePeriod}
                     onChange={(e) =>

--- a/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
+++ b/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
@@ -11,8 +11,6 @@ import {
 } from '../../../../../shared/utils/userInfoUtils';
 import Loading from '../../../../../shared/components/Loading';
 
-// type OutletContext = { setChanges: (changes: Partial<Info>) => void };
-
 const BasicInfoEdit = () => {
   const navigate = useNavigate();
   const { setChanges, editedInfo, setEditedInfo, refs } = useOutletContext<{
@@ -20,21 +18,15 @@ const BasicInfoEdit = () => {
     editedInfo: Info | null;
     setEditedInfo: React.Dispatch<React.SetStateAction<Info | null>>;
     refs: {
-      ageRef: React.RefObject<HTMLInputElement>;
       phoneRef: React.RefObject<HTMLInputElement>;
+      detailAddressRef: React.RefObject<HTMLInputElement>;
       jobRef: React.RefObject<HTMLSelectElement>;
+      experiencePeriodRef: React.RefObject<HTMLSelectElement>;
     };
   }>();
   const [originalInfo, setOriginalInfo] = useState<Info | null>(null);
-  // const [editedInfo, setEditedInfo] = useState<Info | null>(null);
   const [isPhoneEditing, setIsPhoneEditing] = useState<boolean>(false);
   const [isPostcodeOpen, setIsPostCodeOpen] = useState<boolean>(false);
-
-  // ref
-  const phoneRef = useRef<HTMLInputElement>(null);
-  const detailAddressRef = useRef<HTMLInputElement>(null);
-  const jobRef = useRef<HTMLSelectElement>(null);
-  const experiencePeriodRef = useRef<HTMLSelectElement>(null);
 
   const handleRoadAddress = (data: any) => {
     handleChange('roadAddress', data.roadAddress);
@@ -125,7 +117,7 @@ const BasicInfoEdit = () => {
                   </div>
                 ) : label === '연락처' ? (
                   <input
-                    ref={phoneRef}
+                    ref={refs.phoneRef}
                     className="w-[200px] h-[45px] px-[10px] py-[4px] text-center border-[1.3px] border-[#E1E1E1] rounded-[8px] focus:text-black focus:outline-black"
                     value={
                       isPhoneEditing
@@ -145,7 +137,7 @@ const BasicInfoEdit = () => {
                   />
                 ) : label === '상세주소' ? (
                   <input
-                    ref={detailAddressRef}
+                    ref={refs.detailAddressRef}
                     className="w-[200px] h-[45px] px-[10px] py-[4px] text-center border-[1.3px] border-[#E1E1E1] rounded-[8px] focus:text-black focus:outline-black"
                     value={editedInfo?.detailAddress ?? ''}
                     onChange={(e) =>
@@ -155,7 +147,7 @@ const BasicInfoEdit = () => {
                 ) : // 드롭다운메뉴 사용파트
                 label === '직무' ? (
                   <select
-                    ref={jobRef}
+                    ref={refs.jobRef}
                     className="w-[200px] h-[45px] border-[1.3px] border-[#E1E1E1] rounded-[8px] pl-[10px] focus:text-black focus:outline-black"
                     value={editedInfo?.job ?? ''}
                     onChange={(e) =>
@@ -172,7 +164,7 @@ const BasicInfoEdit = () => {
                   </select>
                 ) : label === '기간' ? (
                   <select
-                    ref={experiencePeriodRef}
+                    ref={refs.experiencePeriodRef}
                     className="w-[200px] h-[45px] border-[1.3px] border-[#E1E1E1] rounded-[8px] pl-[10px] focus:text-black focus:outline-black"
                     value={editedInfo?.experiencePeriod}
                     onChange={(e) =>

--- a/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
+++ b/src/pages/Personal/my/seniors/info/BasicInfoEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import DaumPostcode from 'react-daum-postcode';
 import { Info } from '../../../types/userInfo';

--- a/src/pages/Personal/my/seniors/info/ExtraInfo.tsx
+++ b/src/pages/Personal/my/seniors/info/ExtraInfo.tsx
@@ -9,6 +9,7 @@ const ExtraInfo = () => {
   const [questionList, setQuestionList] = useState<Question[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
+  // 시니어 데이터 조회
   useEffect(() => {
     setLoading(true);
     getSeniorData('/api/user/senior/me')
@@ -17,6 +18,7 @@ const ExtraInfo = () => {
       .finally(() => setLoading(false));
   }, []);
 
+  // 시니어 추가질문 정보 조회
   useEffect(() => {
     setLoading(true);
     getSeniorData(`/api/seniors/${info?.id}/questions`)

--- a/src/pages/Personal/my/seniors/info/ExtraInfo.tsx
+++ b/src/pages/Personal/my/seniors/info/ExtraInfo.tsx
@@ -20,6 +20,8 @@ const ExtraInfo = () => {
 
   // 시니어 추가질문 정보 조회
   useEffect(() => {
+    if (!info?.id) return;
+
     setLoading(true);
     getSeniorData(`/api/seniors/${info?.id}/questions`)
       .then((data) => {

--- a/src/pages/Personal/my/seniors/info/ExtraInfoEdit.tsx
+++ b/src/pages/Personal/my/seniors/info/ExtraInfoEdit.tsx
@@ -41,6 +41,8 @@ const ExtraInfoEdit = () => {
 
   // 사용자 질문 리스트 패치
   useEffect(() => {
+    if (!info?.id) return;
+
     setLoading(true);
     getSeniorData(`/api/seniors/${info?.id}/questions`)
       .then((data) => {

--- a/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
+++ b/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
@@ -144,7 +144,12 @@ const SeniorInfo = () => {
                 setChanges,
                 editedInfo,
                 setEditedInfo,
-                refs: { phoneRef, jobRef },
+                refs: {
+                  phoneRef,
+                  detailAddressRef,
+                  jobRef,
+                  experiencePeriodRef,
+                },
               }}
               key={location.pathname}
             />

--- a/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
+++ b/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
@@ -61,22 +61,22 @@ const SeniorInfo = () => {
     if (prevPath === 'basic') {
       try {
         if (!editedInfo?.phone) {
-          alert('연락처를 입력해주세요.');
+          toast.warning('연락처를 입력해주세요.');
           phoneRef.current?.focus();
           return;
         }
         if (!editedInfo?.detailAddress) {
-          alert('상세주소를 입력해주세요.');
+          toast.warning('상세주소를 입력해주세요.');
           detailAddressRef.current?.focus();
           return;
         }
         if (!editedInfo?.job) {
-          alert('직무를 선택해주세요.');
+          toast.warning('직무를 선택해주세요.');
           jobRef.current?.focus();
           return;
         }
         if (!editedInfo?.experiencePeriod) {
-          alert('기간을 선택해주세요.');
+          toast.warning('기간을 선택해주세요.');
           experiencePeriodRef.current?.focus();
           return;
         }

--- a/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
+++ b/src/pages/Personal/my/seniors/info/SeniorInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { NavLink } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -16,6 +16,13 @@ const SeniorInfo = () => {
   // 기본정보 관련
   const [seniorInfo, setSeniorInfo] = useState<Info | null>();
   const [changes, setChanges] = useState<Partial<Info>>({});
+  const [editedInfo, setEditedInfo] = useState<Info | null>(null);
+
+  // ref
+  const phoneRef = useRef<HTMLInputElement>(null);
+  const detailAddressRef = useRef<HTMLInputElement>(null);
+  const jobRef = useRef<HTMLSelectElement>(null);
+  const experiencePeriodRef = useRef<HTMLSelectElement>(null);
 
   // 추가정보 관련
   const [patchObject, setPatchObject] = useState<Answer[]>([]); // patch 객체
@@ -51,18 +58,50 @@ const SeniorInfo = () => {
     const pathArr = location.pathname.split('/');
     const prevPath = pathArr[pathArr.length - 2];
 
-    try {
-      if (prevPath === 'basic') {
+    if (prevPath === 'basic') {
+      try {
+        if (!editedInfo?.phone) {
+          alert('연락처를 입력해주세요.');
+          phoneRef.current?.focus();
+          return;
+        }
+        if (!editedInfo?.detailAddress) {
+          alert('상세주소를 입력해주세요.');
+          detailAddressRef.current?.focus();
+          return;
+        }
+        if (!editedInfo?.job) {
+          alert('직무를 선택해주세요.');
+          jobRef.current?.focus();
+          return;
+        }
+        if (!editedInfo?.experiencePeriod) {
+          alert('기간을 선택해주세요.');
+          experiencePeriodRef.current?.focus();
+          return;
+        }
+
         await axiosInstance.patch('/api/user/senior/me', changes);
-      } else if (prevPath === 'extra') {
+      } catch (err) {
+        console.error('기본 정보 수정 에러: ', err);
+      }
+      navigate(`/personal/senior-my/info/basic`);
+    } else if (prevPath === 'extra') {
+      try {
+        const unselected = patchObject.filter((p) => !p.selectedOptionId);
+        if (unselected.length > 0) {
+          toast.warning(
+            `아직 선택하지 않은 질문: ${unselected.map((p) => p.questionId).join(', ')}`
+          );
+          return;
+        }
         await axiosInstance.patch(`/api/seniors/${seniorInfo?.id}/answers`, {
           answers: patchObject,
         });
+      } catch (err) {
+        console.error('추가 정보 수정 에러: ', err);
       }
-      navigate(`/personal/senior-my/info/${prevPath}`);
-    } catch (err) {
-      console.error('시니어 정보 수정 실패: ', err);
-      toast.error('정보 수정에 실패했습니다.');
+      navigate(`/personal/senior-my/info/extra`);
     }
   };
 
@@ -99,7 +138,14 @@ const SeniorInfo = () => {
           </div>
           <div className="h-[466px]">
             <Outlet
-              context={{ patchObject, setPatchObject, setChanges }}
+              context={{
+                patchObject,
+                setPatchObject,
+                setChanges,
+                editedInfo,
+                setEditedInfo,
+                refs: { phoneRef, jobRef },
+              }}
               key={location.pathname}
             />
           </div>

--- a/src/pages/Personal/types/userInfo.ts
+++ b/src/pages/Personal/types/userInfo.ts
@@ -5,6 +5,7 @@ export type Info = {
   name: string;
   phone: string;
   age: number;
+  gender: 'MALE' | 'FEMALE';
   password: string;
   roadAddress: string;
   detailAddress: string;

--- a/src/pages/Personal/types/userInfo.ts
+++ b/src/pages/Personal/types/userInfo.ts
@@ -92,6 +92,7 @@ export type LinkedSenior = {
   seniorId: number;
   seniorName: string;
   gender: 'MALE' | 'FEMALE';
+  age: number;
   seniorPhone: string;
   roadAddress: string;
   detailAddress: string;

--- a/src/shared/components/field/ImageField.tsx
+++ b/src/shared/components/field/ImageField.tsx
@@ -1,0 +1,43 @@
+import { toast } from 'react-toastify';
+import { MdOutlineFileDownload } from 'react-icons/md';
+import { ImageObject } from '../../../pages/Personal/types/userInfo';
+import axiosInstance from '../../apis/axiosInstance';
+
+interface ImageFieldProps {
+  fieldName: string;
+  answerContent: ImageObject;
+}
+
+const ImageField = ({ fieldName, answerContent }: ImageFieldProps) => {
+  const handleViewFile = async (keyName: string) => {
+    try {
+      const res = await axiosInstance.get(
+        `/api/s3/presigned/download/${keyName}`
+      );
+      window.open(res.data.result.url, '_blank');
+    } catch (err) {
+      console.error('첨부파일 다운로드 실패', err);
+      toast.error('파일을 불러올 수 없습니다.');
+    }
+  };
+
+  return (
+    <div className="flex flex-col text-[14px] font-[Pretendard JP] font-[400]">
+      <div className="flex items-center gap-[4px] mb-[4px]">
+        <span className="text-[#747474]">{fieldName}</span>
+        <span className="text-[#FF0004]">(필수)</span>
+      </div>
+      <div className="flex justify-center gap-[11px]">
+        <div className="flex jusitfy-between items-center w-[297px] h-[45px] p-[12px] rounded-[8px] border-[1.3px] border-[#08D485]">
+          <span className="truncate">{answerContent.originalFileName}</span>
+          <MdOutlineFileDownload
+            size={32}
+            onClick={() => handleViewFile(answerContent.keyName)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImageField;

--- a/src/shared/components/field/TextField.tsx
+++ b/src/shared/components/field/TextField.tsx
@@ -1,0 +1,17 @@
+interface TextFieldProps {
+  fieldName: string;
+  answerContent: string;
+}
+
+const TextField = ({ fieldName, answerContent }: TextFieldProps) => {
+  return (
+    <div className="flex flex-col justify-around w-[297px] h-[134px] rounded-[13px] px-[16px] py-[10px] border-[1.3px] border-[#08D485]">
+      <span className="text-[16px] font-[600] pb-[12px]">{fieldName}</span>
+      <div className="flex justify-between">
+        <span>{answerContent}</span>
+      </div>
+    </div>
+  );
+};
+
+export default TextField;

--- a/src/shared/components/topbar/menu/personal-menu/MainMenu.tsx
+++ b/src/shared/components/topbar/menu/personal-menu/MainMenu.tsx
@@ -96,15 +96,6 @@ const MainMenu = ({ handleMenu }: MainMenuProps) => {
         >
           일자리 신청함
         </MenuNavButton>
-        {accessToken && (
-          <MenuNavButton
-            url={
-              accessToken ? '/personal/senior-my/info/extra' : '/personal/login'
-            }
-          >
-            질문답변
-          </MenuNavButton>
-        )}
         <MenuNavButton
           handleMenu={() => {
             accessToken ? handleMenu(myMenu) : navigate('/personal/login');

--- a/src/shared/utils/userInfoUtils.ts
+++ b/src/shared/utils/userInfoUtils.ts
@@ -39,3 +39,8 @@ export const formatDate = (dateString: string) => {
 
   return date;
 };
+
+// 원 단위 형식으로 만들기
+export const formatMoney = (money: number) => {
+  return money.toLocaleString('ko-KR');
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #171 

## 📝 작업 내용
- 개인(시니어/보호자) 개인정보 수정 시 null 값 입력 방지 -> toast 경고창 띄우기 + 빈 input 태그 포커싱
- 시니어 기본정보조회 api 리스폰스 값 수정 요청 후 gender 필드 추가
- 개인(시니어/보호자) 신청 결과 상세 조회 시 FormFieldAnswer 리스트 항목 보이도록 추가
- 보호자 메뉴에 질문 답변 항목 삭제 옆의 경로로 접근하도록 수정 (내 정보 > 케어중인 시니어 > 추가 정보 입력)
- 메뉴창에서 기업/개인 이름 늦게 뜨는 경우 -> 글자 대신 로딩 스피너로 대체 (깜박거리는 효과 줄임)
- 필요없는 코드 및 주석 삭제

## 🖼️ 구현 화면


## 💬 리뷰 요구사항(선택)

<br />
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
